### PR TITLE
remove-py38-new-api

### DIFF
--- a/zeno/dll.py
+++ b/zeno/dll.py
@@ -4,10 +4,7 @@ from zenutils import rel2abs, os_name
 
 if os_name == 'win32':
     dllpath = rel2abs(__file__, 'lib')
-    if hasattr(os, 'add_dll_directory'):
-        os.add_dll_directory(dllpath)
-    else:
-        os.environ['PATH'] += os.pathsep + dllpath
+    os.environ['PATH'] += os.pathsep + dllpath
     ctypes.cdll.LoadLibrary('zeno.dll')
 elif os_name == 'darwin':
     ctypes.cdll.LoadLibrary(rel2abs(__file__, 'lib', 'libzeno.dylib'))


### PR DESCRIPTION
python 3.8  new api os.add_dll_directory doesn't work in my pc.
use the old way