### PR TITLE
bugfix-encoding-win

### DIFF
--- a/zenqt/ui/editor/locale.py
+++ b/zenqt/ui/editor/locale.py
@@ -5,7 +5,7 @@ translation = {}
 @eval('lambda x: x()')
 def load_translation():
     translation.clear()
-    with open(asset_path('zh-cn.txt'), 'r') as f:
+    with open(asset_path('zh-cn.txt'), 'r', encoding='utf-8') as f:
         for line in f.readlines():
             try:
                 en, zh = line.split(' ', maxsplit=1)


### PR DESCRIPTION
python default encoding is gbk not utf8 on Win.