### PR TITLE
fix syntax mistake in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,44 +1,44 @@
 {
   "name": "zeno",
   "version": "0.0.1",
-  "features": [
-      "qt": {
-          "description": "Install Qt with vcpkg",
-          "dependencies": [
-            {
-                "name": "qt",
-                "version>=": "5.14.0"
-            }
-          ]
-      },
-      "openvdb": {
-          "description": "Enable volumetric nodes, including the FLIP solver",
-          "dependencies": [
-            "tbb",
-            "eigen3",
-            {
-                "name": "openvdb",
-                "version>=": "8.0.0"
-            }
-          ]
-      },
-      "cgmesh": {
-          "description": "Enable mesh processing nodes",
-          "dependencies": [
-            "openblas",
-            "lapack"
-          ]
-      },
-      "alembic": {
-          "description": "Enable Alembic nodes, for .abc format support",
-          "dependencies": [
-            {
-                "name": "alembic",
-                "features": "hdf5"
-            }
-          ]
-      }
-  ],
+  "features": {
+    "qt": {
+      "description": "Install Qt with vcpkg",
+      "dependencies": [
+        {
+          "name": "qt",
+          "version>=": "5.14.0"
+        }
+      ]
+    },
+    "openvdb": {
+      "description": "Enable volumetric nodes, including the FLIP solver",
+      "dependencies": [
+        "tbb",
+        "eigen3",
+        {
+          "name": "openvdb",
+          "version>=": "8.0.0"
+        }
+      ]
+    },
+    "cgmesh": {
+      "description": "Enable mesh processing nodes",
+      "dependencies": [
+        "openblas",
+        "lapack"
+      ]
+    },
+    "alembic": {
+      "description": "Enable Alembic nodes, for .abc format support",
+      "dependencies": [
+        {
+          "name": "alembic",
+          "features": [ "hdf5" ]
+        }
+      ]
+    }
+  },
   "default-features": [
       "qt", "openvdb"
   ]


### PR DESCRIPTION
<!--
  -- Thank for you contribution!
  -- Contributor guidelines: https://github.com/zenustech/zeno/blob/master/CONTRIBUTING.md
  -->
if on windows, there will be an error when **vcpkg Manifest Mode** is on:

![image](https://user-images.githubusercontent.com/40262194/157166148-6d011536-cf5a-424d-a0df-43daa1a6573a.png)
![image](https://user-images.githubusercontent.com/40262194/157166246-b4351a8b-b8cc-4a0b-94be-1b3174fbd70a.png)

refer to the example in [vcpkg manifests](https://github.com/microsoft/vcpkg/blob/master/docs/users/manifests.md)
