### PR TITLE
fix-win-c2026

### DIFF
--- a/zenvis/GraphicPrimitive.cpp
+++ b/zenvis/GraphicPrimitive.cpp
@@ -1287,6 +1287,7 @@ vec3 histThings(vec3 s)
     ls = ceil(ls/0.2)*0.2;
     return norms * ls;
 }
+)" + R"(
 vec3 ToonBRDF(vec3 baseColor, float metallic, float subsurface, 
 float specular, 
 float roughness,


### PR DESCRIPTION
D:\zeno\zenvis\GraphicPrimitive.cpp(1327,1): error C2026: 字符串太大，已截断尾部字符 [D:\zeno\build\zenvis\pylib_zenvis.vcxproj]
字符串的长度超过 16380 个单字节字符的限制。