### PR TITLE
FileNotFoundError: [WinError 3] 系统找不到指定的路径。

### DIFF
--- a/zenqt/ui/visualize/viewport.py
+++ b/zenqt/ui/visualize/viewport.py
@@ -226,7 +226,10 @@ class QDMDisplayMenu(QMenu):
         self.addAction(action)
 
 def get_env_tex_names():
-    ns = os.listdir('assets/sky_box')
+    current_path = os.path.abspath(__file__)
+    father_path = os.path.abspath(os.path.dirname(current_path) + os.path.sep + ".")
+    zenqt_dir = os.path.abspath(os.path.dirname(father_path) + os.path.sep + "..")
+    ns = os.path.join(os.path.abspath(os.path.dirname(zenqt_dir) ), 'assets\sky_box')
     return list(ns)
 
 env_texs = get_env_tex_names()


### PR DESCRIPTION
Test OK in Project zeno_addon_wizard and Project Zeno in windows + vs2019
such as:
ZENO repo directory at: C:\zeno\zeno
当前目录:C:\zeno\zeno\zenqt\ui\visualize\viewport.py
zenqt_dir目录:C:\zeno\zeno\zenqt
ns路径:C:\zeno\zeno\assets\sky_box

<!--
  -- Thank for you contribution!
  -- Contributor guidelines: https://github.com/zenustech/zeno/blob/master/CONTRIBUTING.md
  -->

Related issue number (if any) = #...
