### PR TITLE
fix instFrame

### DIFF
--- a/zenovis/zhxxvis/GraphicPrimitive.cpp
+++ b/zenovis/zhxxvis/GraphicPrimitive.cpp
@@ -670,9 +670,9 @@ struct GraphicPrimitive : IGraphic {
 
         if (prim_has_inst)
         {
-            triObj.prog->set_uniform("fInstDeltaTime", prim_inst_delta_time);
-            triObj.prog->set_uniformi("iInstFrameAmount", prim_inst_frame_amount);
-            triObj.prog->set_uniformi("iInstVertexFrameSampler",texOcp);
+            triObj.shadowprog->set_uniform("fInstDeltaTime", prim_inst_delta_time);
+            triObj.shadowprog->set_uniformi("iInstFrameAmount", prim_inst_frame_amount);
+            triObj.shadowprog->set_uniformi("iInstVertexFrameSampler",texOcp);
             prim_inst_vertex_frame_sampler->bind_to(texOcp);
             texOcp++;
         }


### PR DESCRIPTION
instFrame是以前zeno2的分支，和现在差异过大，无法自动合并然后去pr，所以再开一个fixInstFrameMaster的分支给现在这个分支合并。
加了instFrame功能，但是没有结合mtl来一起测试。
在shadowPass那里，手误写错了。
现在修复：

![8521652981943_ pic](https://user-images.githubusercontent.com/74554469/169374463-364d17c2-0348-47fd-8b6d-18d7592810d2.jpg)

