### PR TITLE
Zeno2 fixbug

### DIFF
--- a/ui/zenoedit/launch/viewdecode.cpp
+++ b/ui/zenoedit/launch/viewdecode.cpp
@@ -1,5 +1,7 @@
 #ifdef ZENO_MULTIPROCESS
 #include "viewdecode.h"
+#include "zenoapplication.h"
+#include "zenomainwindow.h"
 #include <zeno/utils/log.h>
 #include <zeno/types/UserData.h>
 #include <zeno/core/Session.h>
@@ -70,6 +72,9 @@ struct PacketProc {
             }
             clearGlobalIfNeeded();
             zeno::getSession().globalComm->addViewObject(objKey, object);
+
+            //need to notify the GL to update.
+            zenoApp->getMainWindow()->updateViewport();
 
         } else if (action == "newFrame") {
             globalCommNeedNewFrame = 1; // postpone `zeno::getSession().globalComm->newFrame();`

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -507,7 +507,6 @@ void ZenoNode::initParam(PARAM_CONTROL ctrl, QGraphicsLinearLayout* pParamLayout
 			    onParamEditFinished(param.control, paramName, pFileWidget->text());
 			});
             connect(openBtn, &ZenoImageItem::clicked, this, [=]() {
-                DlgInEventLoopScope;
                 QString path = QFileDialog::getOpenFileName(nullptr, "File to Open", "", "All Files(*);;");
                 if (path.isEmpty())
                     return;
@@ -536,7 +535,6 @@ void ZenoNode::initParam(PARAM_CONTROL ctrl, QGraphicsLinearLayout* pParamLayout
 			    onParamEditFinished(param.control, paramName, pFileWidget->text());
 			});
             connect(openBtn, &ZenoImageItem::clicked, this, [=]() {
-                DlgInEventLoopScope;
                 QString path = QFileDialog::getSaveFileName(nullptr, "Path to Save", "", "All Files(*);;");
                 if (path.isEmpty())
                     return;
@@ -877,7 +875,6 @@ QGraphicsLayout* ZenoNode::initSockets()
 
                     ZenoSvgLayoutItem *openBtn = new ZenoSvgLayoutItem(elem, QSizeF(30, 30));
                     connect(openBtn, &ZenoImageItem::clicked, this, [=]() {
-                        DlgInEventLoopScope;
                         QString path;
                         if (isRead) {
                             path = QFileDialog::getOpenFileName(nullptr, "File to Open", "", "All Files(*);;");

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -441,6 +441,7 @@ DisplayWidget::DisplayWidget(ZenoMainWindow* pMainWin)
     , m_view(nullptr)
     , m_timeline(nullptr)
     , m_mainWin(pMainWin)
+    , m_pTimer(nullptr)
 {
     QVBoxLayout* pLayout = new QVBoxLayout;
     pLayout->setContentsMargins(0, 0, 0, 0);
@@ -472,17 +473,16 @@ DisplayWidget::DisplayWidget(ZenoMainWindow* pMainWin)
     Zenovis::GetInstance().m_camera_keyframe = m_camera_keyframe;
 
 	connect(&Zenovis::GetInstance(), SIGNAL(frameUpdated(int)), m_timeline, SLOT(onTimelineUpdate(int)));
-	connect(m_timeline, SIGNAL(playForward(bool)), &Zenovis::GetInstance(), SLOT(startPlay(bool)));
-	connect(m_timeline, SIGNAL(sliderValueChanged(int)), &Zenovis::GetInstance(), SLOT(setCurrentFrameId(int)));
+    connect(m_timeline, SIGNAL(playForward(bool)), this, SLOT(onPlayClicked(bool)));
+	connect(m_timeline, SIGNAL(sliderValueChanged(int)), this, SLOT(onSliderValueChanged(int)));
 	connect(m_timeline, SIGNAL(run()), this, SLOT(onRun()));
     connect(m_timeline, SIGNAL(kill()), this, SLOT(onKill()));
-    
+
     auto graphs = zenoApp->graphsManagment();
     connect(graphs.get(), SIGNAL(modelDataChanged()), this, SLOT(onModelDataChanged()));
 
-	QTimer* pTimer = new QTimer;
-	connect(pTimer, SIGNAL(timeout()), this, SLOT(updateFrame()));
-	pTimer->start(16);
+	m_pTimer = new QTimer(this);
+    connect(m_pTimer, SIGNAL(timeout()), this, SLOT(updateFrame()));
 }
 
 DisplayWidget::~DisplayWidget()
@@ -513,6 +513,21 @@ void DisplayWidget::onModelDataChanged()
     {
         onRun();
     }
+}
+
+void DisplayWidget::onPlayClicked(bool bChecked)
+{
+    if (bChecked)
+        m_pTimer->start(16);
+    else
+        m_pTimer->stop();
+    Zenovis::GetInstance().startPlay(bChecked);
+}
+
+void DisplayWidget::onSliderValueChanged(int value)
+{
+    Zenovis::GetInstance().setCurrentFrameId(value);
+    updateFrame();
 }
 
 void DisplayWidget::onRun()

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -502,8 +502,6 @@ QSize DisplayWidget::sizeHint() const
 
 void DisplayWidget::updateFrame()
 {
-    if (m_mainWin && m_mainWin->inDlgEventLoop())
-        return;
     m_view->update();
 }
 

--- a/ui/zenoedit/viewport/viewportwidget.h
+++ b/ui/zenoedit/viewport/viewportwidget.h
@@ -94,6 +94,8 @@ public slots:
     void onRun();
     void onKill();
     void onModelDataChanged();
+    void onPlayClicked(bool);
+    void onSliderValueChanged(int);
 
 signals:
     void frameUpdated(int new_frame);
@@ -103,6 +105,7 @@ private:
     ZTimeline* m_timeline;
     ZenoMainWindow* m_mainWin;
     CameraKeyframeWidget* m_camera_keyframe;
+    QTimer* m_pTimer;
 };
 
 #endif

--- a/ui/zenoedit/zenoapplication.h
+++ b/ui/zenoedit/zenoapplication.h
@@ -43,9 +43,4 @@ private:
 
 #define zenoApp (qobject_cast<ZenoApplication*>(QApplication::instance()))
 
-#define DlgInEventLoopScope  \
-    zeno::scope_exit sp([=]() {zenoApp->getMainWindow()->setInDlgEventLoop(false);});\
-    zenoApp->getMainWindow()->setInDlgEventLoop(true);    
-
-
 #endif

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -380,7 +380,6 @@ static bool saveContent(const QString &strContent, QString filePath) {
 }
 
 void ZenoMainWindow::exportGraph() {
-    DlgInEventLoopScope;
     QString path = QFileDialog::getSaveFileName(this, "Path to Save", "",
                                                 "C++ Source File(*.cpp);; JSON file(*.json);; All Files(*);;");
     if (path.isEmpty()) {
@@ -557,16 +556,7 @@ bool ZenoMainWindow::saveFile(QString filePath) {
     return true;
 }
 
-bool ZenoMainWindow::inDlgEventLoop() const {
-    return m_bInDlgEventloop;
-}
-
-void ZenoMainWindow::setInDlgEventLoop(bool bOn) {
-    m_bInDlgEventloop = bOn;
-}
-
 void ZenoMainWindow::saveAs() {
-    DlgInEventLoopScope;
     QString path = QFileDialog::getSaveFileName(this, "Path to Save", "", "Zensim Graph File(*.zsg);; All Files(*);;");
     if (!path.isEmpty()) {
         saveFile(path);
@@ -574,7 +564,6 @@ void ZenoMainWindow::saveAs() {
 }
 
 QString ZenoMainWindow::getOpenFileByDialog() {
-    DlgInEventLoopScope;
     const QString &initialPath = ".";
     QFileDialog fileDialog(this, tr("Open"), initialPath, "Zensim Graph File (*.zsg)\nAll Files (*)");
     fileDialog.setAcceptMode(QFileDialog::AcceptOpen);

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -292,6 +292,14 @@ void ZenoMainWindow::onMaximumTriggered()
     }
 }
 
+void ZenoMainWindow::updateViewport()
+{
+    //todo: temp code for single view.
+    DisplayWidget* view = qobject_cast<DisplayWidget*>(m_viewDock->widget());
+    if (view)
+        view->updateFrame();
+}
+
 void ZenoMainWindow::onSplitDock(bool bHorzontal)
 {
     ZenoDockWidget *pDockWidget = qobject_cast<ZenoDockWidget *>(sender());

--- a/ui/zenoedit/zenomainwindow.h
+++ b/ui/zenoedit/zenomainwindow.h
@@ -13,9 +13,7 @@ class ZenoMainWindow : public QMainWindow
 public:
     ZenoMainWindow(QWidget* parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
     ~ZenoMainWindow();
-    ZenoGraphsEditor* editor() const { return m_pEditor; };
-    bool inDlgEventLoop() const;
-    void setInDlgEventLoop(bool bOn);
+    ZenoGraphsEditor* editor() const { return m_pEditor; }
 
 public slots:
     void onRunClicked(int beginFrame, int endFrame);

--- a/ui/zenoedit/zenomainwindow.h
+++ b/ui/zenoedit/zenomainwindow.h
@@ -33,6 +33,7 @@ public slots:
     void importGraph();
     void exportGraph();
     void onNodesSelected(const QModelIndex& subgIdx, const QModelIndexList& nodes, bool select);
+    void updateViewport();
 
 protected:
     void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
remove timer about updating viewport anytime, and manually update frame instead when
1. add viewobject by core proc.
2. update timeline.
3. play toggled.
