### PR TITLE
make viewport interactive (naive version)

### DIFF
--- a/ui/zenoedit/nodesys/nodesmgr.cpp
+++ b/ui/zenoedit/nodesys/nodesmgr.cpp
@@ -10,7 +10,7 @@
 #include "curvemap/curveutil.h"
 
 
-void NodesMgr::createNewNode(IGraphsModel* pModel, QModelIndex subgIdx, const QString& descName, const QPointF& pt)
+QString NodesMgr::createNewNode(IGraphsModel* pModel, QModelIndex subgIdx, const QString& descName, const QPointF& pt)
 {
     zeno::log_debug("onNewNodeCreated");
     NODE_DESCS descs = pModel->descriptors();
@@ -32,6 +32,8 @@ void NodesMgr::createNewNode(IGraphsModel* pModel, QModelIndex subgIdx, const QS
     node[ROLE_COLLASPED] = false;
 
     pModel->addNode(node, subgIdx, true);
+
+    return nodeid;
 }
 
 NODE_TYPE NodesMgr::nodeType(const QString& name)

--- a/ui/zenoedit/nodesys/nodesmgr.h
+++ b/ui/zenoedit/nodesys/nodesmgr.h
@@ -10,7 +10,7 @@ class NodesMgr : public QObject
 {
 	Q_OBJECT
 public:
-	static void createNewNode(IGraphsModel* pModel, QModelIndex subgIdx, const QString& descName, const QPointF& pt);
+	static QString createNewNode(IGraphsModel* pModel, QModelIndex subgIdx, const QString& descName, const QPointF& pt);
 	static NODE_TYPE nodeType(const QString& name);
     static void initInputSocks(IGraphsModel* pModel, const QString& nodeid, INPUT_SOCKETS& descInputs);
 	static void initOutputSocks(IGraphsModel* pModel, const QString& nodeid, OUTPUT_SOCKETS& descOutputs);

--- a/ui/zenoedit/viewport/viewporttransform.h
+++ b/ui/zenoedit/viewport/viewporttransform.h
@@ -1,0 +1,339 @@
+//
+// Created by ryan on 22-8-8.
+//
+
+#ifndef __VIEWPORT_TRANSFORM_H__
+#define __VIEWPORT_TRANSFORM_H__
+#include "zenovis.h"
+
+#include <zeno/types/PrimitiveObject.h>
+#include <zeno/funcs/PrimitiveTools.h>
+#include <zeno/types/UserData.h>
+#include <zenovis/ObjectsManager.h>
+
+#include <QtWidgets>
+
+#include <glm/glm.hpp>
+#include <glm/gtx/transform.hpp>
+
+#include <unordered_map>
+
+namespace zeno {
+
+class FakeTransformer {
+  public:
+    FakeTransformer()
+    : transform_matrix(1.0f)
+    , scale_matrix(1.0f)
+    , rotate_matrix(1.0f)
+    , translate_matrix(1.0f)
+    , step_transform_matrix(1.0f)
+    , objects_center(0.0f)
+    , status(false)
+    , rotate_eular_vec(0.0f)
+    {
+
+    }
+
+    FakeTransformer(const std::unordered_set<std::string>& names)
+    : transform_matrix(1.0f)
+    , scale_matrix(1.0f)
+    , rotate_matrix(1.0f)
+    , translate_matrix(1.0f)
+    , step_transform_matrix(1.0f)
+    , objects_center(0.0f)
+    , status(true)
+    , rotate_eular_vec(0.0f)
+    {
+        addObject(names);
+    }
+
+    void addObject(const std::string& name) {
+        auto nm = name.substr(0, name.find_first_of(':'));
+        // printf(nm.c_str());
+        // printf("\n");
+        auto scene = Zenovis::GetInstance().getSession()->get_scene();
+        auto object = dynamic_cast<PrimitiveObject*>(scene->objectsMan->get(name).value());
+        objects_center *= objects.size();
+        auto user_data = object->userData();
+        zeno::vec3f bmin, bmax;
+        if (user_data.has("_bboxMin") && user_data.has("_bboxMax")) {
+            bmin = user_data.getLiterial<zeno::vec3f>("_bboxMin");
+            bmax = user_data.getLiterial<zeno::vec3f>("_bboxMax");
+        } else {
+            std::tie(bmin, bmax) = zeno::primBoundingBox(object);
+            user_data.setLiterial("_bboxMin", bmin);
+            user_data.setLiterial("_bboxMax", bmax);
+        }
+        auto m = zeno::vec_to_other<glm::vec3>(bmax);
+        auto n = zeno::vec_to_other<glm::vec3>(bmin);
+        objects_center += (m + n) / 2.0f;
+        objects[name] = object;
+        objects_center /= objects.size();
+    }
+
+    void addObject(const std::unordered_set<std::string>& names) {
+        for (const auto& name : names) {
+            addObject(name);
+        }
+    }
+
+    void removeObject(const std::string& name) {
+        auto p = objects.find(name);
+        if (p == objects.end())
+            return ;
+        auto object = p->second;
+        objects_center *= objects.size();
+        auto user_data = object->userData();
+        zeno::vec3f bmin, bmax;
+        if (user_data.has("_bboxMin") && user_data.has("_bboxMax")) {
+            bmin = user_data.getLiterial<zeno::vec3f>("_bboxMin");
+            bmax = user_data.getLiterial<zeno::vec3f>("_bboxMax");
+        } else {
+            std::tie(bmin, bmax) = zeno::primBoundingBox(object);
+            user_data.setLiterial("_bboxMin", bmin);
+            user_data.setLiterial("_bboxMax", bmax);
+        }
+        auto m = zeno::vec_to_other<glm::vec3>(bmax);
+        auto n = zeno::vec_to_other<glm::vec3>(bmin);
+        objects_center -= (m + n) / 2.0f;
+        objects.erase(p);
+        objects_center /= objects.size();
+    }
+
+    void removeObject(const std::unordered_set<std::string>& names) {
+        for (const auto& name : names) {
+            removeObject(name);
+        }
+    }
+
+    void translate(QVector3D start, QVector3D end, QVector3D axis) {
+        auto diff = end - start;
+        glm::vec3 diff_vec3 = QVec3ToGLMVec3(diff);
+        diff_vec3 *= QVec3ToGLMVec3(axis);
+        step_transform_matrix = glm::translate(diff_vec3);
+        translate_matrix = step_transform_matrix * translate_matrix;
+        transform_matrix = step_transform_matrix * transform_matrix;
+        doTransform();
+    }
+
+    void print_mat4(glm::mat4 mat) const {
+        printf("\n");
+        for (int i=0; i<4; i++) {
+            for (int j=0; j<4; j++)
+                printf("%.2lf ", transform_matrix[i][j]);
+            printf("\n");
+        }
+    }
+
+    void scale(QVector3D cur_vec, vec3i axis, float scale_size) {
+        glm::vec3 cur_vec3 = QVec3ToGLMVec3(cur_vec);
+        glm::vec3 scale(1.0f);
+        for (int i=0; i<3; i++)
+            if (axis[i] == 1) scale[i] = scale_size * 3;
+        auto inv_last_scale = glm::inverse(scale_matrix);
+        scale_matrix = glm::scale(scale);
+        auto translate_to_origin = glm::translate(-objects_center);
+        auto translate_to_center = glm::translate(objects_center);
+        step_transform_matrix = translate_to_center * scale_matrix * inv_last_scale * translate_to_origin;
+        transform_matrix = step_transform_matrix * transform_matrix;
+        doTransform();
+    }
+
+    void rotate(QVector3D start_vec, QVector3D end_vec, QVector3D axis) {
+        glm::vec3 start_vec3 = QVec3ToGLMVec3(start_vec);
+        glm::vec3 end_vec3 = QVec3ToGLMVec3(end_vec);
+        glm::vec3 axis_vec3 = QVec3ToGLMVec3(axis);
+        start_vec3 = glm::normalize(start_vec3);
+        end_vec3 = glm::normalize(end_vec3);
+        auto cross_vec3 = glm::cross(start_vec3, end_vec3);
+        float direct = 1.0f;
+        if (glm::dot(cross_vec3, axis_vec3) < 0)
+            direct = -1.0f;
+        float angle = acos(fmin(fmax(glm::dot(start_vec3, end_vec3), -1.0f), 1.0f));
+        rotate_eular_vec += angle * direct * axis_vec3;
+        step_transform_matrix = glm::rotate(angle * direct, axis_vec3);
+        auto translate_to_origin = glm::translate(-objects_center);
+        auto translate_to_center = glm::translate(objects_center);
+        step_transform_matrix = translate_to_center * step_transform_matrix * translate_to_origin;
+        rotate_matrix = step_transform_matrix * rotate_matrix;
+        transform_matrix = step_transform_matrix * transform_matrix;
+        doTransform();
+    }
+
+    glm::vec3 getTranslateVec() const {
+        return {translate_matrix[3][0], translate_matrix[3][1], translate_matrix[3][2]};
+    }
+
+    glm::vec3 getScaleVec() const {
+        return {scale_matrix[0][0], scale_matrix[1][1], scale_matrix[2][2]};
+    }
+
+    glm::vec3 getRotateEulerVec() const {
+        return rotate_eular_vec;
+    }
+
+    void startTransform() {
+        status = true;
+        Zenovis::GetInstance().getSession()->set_interactive(true);
+    }
+
+    void endTransform() {
+        status = false;
+        translate_matrix = glm::mat4(1.0f);
+        scale_matrix = glm::mat4(1.0f);
+        rotate_eular_vec = glm::vec3(1.0f);
+        Zenovis::GetInstance().getSession()->set_interactive(false);
+    }
+
+    bool isTransforming() const {
+        return status;
+    }
+
+    glm::vec3 getCenter() {
+        return objects_center;
+    }
+
+    void clear() {
+        objects.clear();
+        objects_center = {0, 0, 0};
+        transform_matrix = glm::mat4(1.0f);
+        scale_matrix = glm::mat4(1.0f);
+        rotate_matrix = glm::mat4(1.0f);
+        translate_matrix = glm::mat4(1.0f);
+        step_transform_matrix = glm::mat4(1.0f);
+        objects_center = {0, 0, 0};
+        rotate_eular_vec = {0, 0, 0};
+    }
+
+  private:
+    static glm::vec3 QVec3ToGLMVec3(QVector3D QVec3) {
+        return {QVec3.x(), QVec3.y(), QVec3.z()};
+    }
+
+    void doTransform() {
+        for (auto &[obj_name, obj] : objects) {
+            if (obj->has_attr("pos")) {
+                // transform pos
+                auto &pos = obj->attr<zeno::vec3f>("pos");
+                for (auto &po : pos) {
+                    auto p = zeno::vec_to_other<glm::vec3>(po);
+                    auto t = step_transform_matrix * glm::vec4(p, 1.0f);
+                    auto pt = glm::vec3(t) / t.w;
+                    po = zeno::other_to_vec<3>(pt);
+                }
+            }
+            if (obj->has_attr("nrm")) {
+                // transform nrm
+                auto &nrm = obj->attr<zeno::vec3f>("nrm");
+                for (auto &i : nrm) {
+                    auto n = zeno::vec_to_other<glm::vec3>(i);
+                    glm::mat3 norm_matrix(step_transform_matrix);
+                    norm_matrix = glm::transpose(glm::inverse(norm_matrix));
+                    auto t = glm::normalize(norm_matrix * n);
+                    i = zeno::other_to_vec<3>(n);
+                }
+            }
+            auto &user_data = obj->userData();
+            if (user_data.has("_bboxMin") && user_data.has("_bboxMax")) {
+                vec3f bmin, bmax;
+                std::tie(bmin, bmax) = primBoundingBox(obj);
+                user_data.setLiterial("_bboxMin", bmin);
+                user_data.setLiterial("_bboxMax", bmax);
+            }
+        }
+        // update center
+        glm::vec4 center(objects_center, 1);
+        center = step_transform_matrix * center;
+        center /= center[3];
+        objects_center = center;
+    }
+
+  private:
+    std::unordered_map<std::string, PrimitiveObject*> objects;
+
+    glm::mat4 translate_matrix;
+    glm::mat4 scale_matrix;
+    glm::mat4 rotate_matrix;
+    glm::mat4 transform_matrix;
+    glm::mat4 step_transform_matrix;
+
+    glm::vec3 rotate_eular_vec;
+
+    glm::vec3 objects_center;
+
+    bool status;
+};
+
+//void getTranslateTransformMatrix(glm::mat4 &matrix, QVector3D start, QVector3D end, QVector3D axis);
+//void getTranslateTransformMatrix(glm::mat4 &matrix, QVector3D start, QVector3D end, QVector3D axis) {
+//    auto diff = end - start;
+//    glm::vec3 diff_vec3 = QVec3ToGLMVec3(diff);
+//    diff_vec3 *= QVec3ToGLMVec3(axis);
+//    matrix = glm::translate(diff_vec3);
+//}
+//
+////void print_vec3(std::string name, glm::vec3 vec) {
+////    printf("%s: %.2lf, %.2lf, %.2lf // ", name.c_str(), vec[0], vec[1], vec[2]);
+////}
+//
+//void getRotateTransformMatrix(glm::mat4 &matrix, QVector3D start_vec, QVector3D end_vec, QVector3D axis);
+//void getRotateTransformMatrix(glm::mat4 &matrix, QVector3D start_vec, QVector3D end_vec, QVector3D axis) {
+//    glm::vec3 start_vec3 = QVec3ToGLMVec3(start_vec);
+//    glm::vec3 end_vec3 = QVec3ToGLMVec3(end_vec);
+//    glm::vec3 axis_vec3 = QVec3ToGLMVec3(axis);
+//    start_vec3 = glm::normalize(start_vec3);
+//    end_vec3 = glm::normalize(end_vec3);
+//    auto cross_vec3 = glm::cross(start_vec3, end_vec3);
+//    float direct = 1.0f;
+//    if (glm::dot(cross_vec3, axis_vec3) < 0)
+//        direct = -1.0f;
+//    float angle = acos(fmin(fmax(glm::dot(start_vec3, end_vec3), -1.0f), 1.0f));
+//    matrix = glm::rotate(angle * direct, axis_vec3);
+//}
+//
+//void getScaleTransformMatrix(glm::mat4 &matrix, QVector3D cur_vec, vec3i axis, float scale_size);
+//void getScaleTransformMatrix(glm::mat4 &matrix, QVector3D cur_vec, vec3i axis, float scale_size) {
+//    glm::vec3 cur_vec3 = QVec3ToGLMVec3(cur_vec);
+//    glm::vec3 scale(1.0f);
+//    for (int i=0; i<3; i++)
+//        if (axis[i] == 1) scale[i] = scale_size * 3;
+//    matrix = glm::scale(scale);
+//}
+//
+//void doFakeTransformPrimitive(zeno::PrimitiveObject *obj, glm::mat4 transform_matrix);
+//void doFakeTransformPrimitive(zeno::PrimitiveObject *obj, glm::mat4 const transform_matrix) {
+//
+//    if (obj->has_attr("pos")) {
+//        // transform pos
+//        auto &pos = obj->attr<zeno::vec3f>("pos");
+//        for (auto &po : pos) {
+//            auto p = zeno::vec_to_other<glm::vec3>(po);
+//            auto t = transform_matrix * glm::vec4(p, 1.0f);
+//            auto pt = glm::vec3(t) / t.w;
+//            po = zeno::other_to_vec<3>(pt);
+//        }
+//    }
+//    if (obj->has_attr("nrm")) {
+//        // transform nrm
+//        auto &nrm = obj->attr<zeno::vec3f>("nrm");
+//        for (auto &i : nrm) {
+//            auto n = zeno::vec_to_other<glm::vec3>(i);
+//            glm::mat3 norm_matrix(transform_matrix);
+//            norm_matrix = glm::transpose(glm::inverse(norm_matrix));
+//            auto t = glm::normalize(norm_matrix * n);
+//            i = zeno::other_to_vec<3>(n);
+//        }
+//    }
+//    auto &user_data = obj->userData();
+//    if (user_data.has("_bboxMin") && user_data.has("_bboxMax")) {
+//        vec3f bmin, bmax;
+//        std::tie(bmin, bmax) = primBoundingBox(obj);
+//        user_data.setLiterial("_bboxMin", bmin);
+//        user_data.setLiterial("_bboxMax", bmax);
+//    }
+//}
+
+}
+
+#endif //__VIEWPORT_TRANSFORM_H__

--- a/ui/zenoedit/viewport/viewporttransform.h
+++ b/ui/zenoedit/viewport/viewporttransform.h
@@ -10,6 +10,7 @@
 #include <zeno/funcs/PrimitiveTools.h>
 #include <zeno/types/UserData.h>
 #include <zenovis/ObjectsManager.h>
+#include <nodesys/nodesmgr.h>
 
 #include <QtWidgets>
 
@@ -19,6 +20,13 @@
 #include <unordered_map>
 
 namespace zeno {
+
+enum {
+    TRANSLATE,
+    ROTATE,
+    SCALE,
+    NONE
+};
 
 class FakeTransformer {
   public:
@@ -31,6 +39,7 @@ class FakeTransformer {
     , objects_center(0.0f)
     , status(false)
     , rotate_eular_vec(0.0f)
+    , operation(NONE)
     {
 
     }
@@ -44,6 +53,7 @@ class FakeTransformer {
     , objects_center(0.0f)
     , status(true)
     , rotate_eular_vec(0.0f)
+    , operation(NONE)
     {
         addObject(names);
     }
@@ -115,6 +125,7 @@ class FakeTransformer {
         translate_matrix = step_transform_matrix * translate_matrix;
         transform_matrix = step_transform_matrix * transform_matrix;
         doTransform();
+        operation = TRANSLATE;
     }
 
     void print_mat4(glm::mat4 mat) const {
@@ -138,6 +149,7 @@ class FakeTransformer {
         step_transform_matrix = translate_to_center * scale_matrix * inv_last_scale * translate_to_origin;
         transform_matrix = step_transform_matrix * transform_matrix;
         doTransform();
+        operation = SCALE;
     }
 
     void rotate(QVector3D start_vec, QVector3D end_vec, QVector3D axis) {
@@ -159,18 +171,148 @@ class FakeTransformer {
         rotate_matrix = step_transform_matrix * rotate_matrix;
         transform_matrix = step_transform_matrix * transform_matrix;
         doTransform();
+        operation = ROTATE;
     }
 
-    glm::vec3 getTranslateVec() const {
+    inline glm::vec3 getTranslateVec() const {
         return {translate_matrix[3][0], translate_matrix[3][1], translate_matrix[3][2]};
     }
 
-    glm::vec3 getScaleVec() const {
+    inline glm::vec3 getScaleVec() const {
         return {scale_matrix[0][0], scale_matrix[1][1], scale_matrix[2][2]};
     }
 
-    glm::vec3 getRotateEulerVec() const {
+    inline glm::vec3 getRotateEulerVec() const {
         return rotate_eular_vec;
+    }
+
+    void createNewTransformNode(QString& node_id, IGraphsModel* pModel, QModelIndex& node_index, QModelIndex& subgraph_index, bool change_visibility=true) const {
+        auto pos = node_index.data(ROLE_OBJPOS).toPointF();
+        pos.setX(pos.x() + 10);
+        auto new_node_id = NodesMgr::createNewNode(pModel, subgraph_index, "TransformPrimitive", pos);
+        QString out_sock = "prim";
+        if (node_id.contains("TransformPrimitive"))
+            out_sock = "outPrim";
+        EdgeInfo edge = {
+            node_id,
+            new_node_id,
+            out_sock,
+            "prim"
+        };
+        pModel->addLink(edge, subgraph_index, false);
+
+        auto translate_vec3 = getTranslateVec();
+        QVector<double> translate = {
+            translate_vec3[0],
+            translate_vec3[1],
+            translate_vec3[2]
+        };
+        PARAM_UPDATE_INFO translate_info = {
+            "translation",
+            QVariant::fromValue(QVector<double>{0, 0, 0}),
+            QVariant::fromValue(translate)
+        };
+        pModel->updateSocketDefl(new_node_id, translate_info, subgraph_index, true);
+
+        auto scaling_vec3 = getScaleVec();
+        QVector<double> scaling = {
+            scaling_vec3[0],
+            scaling_vec3[1],
+            scaling_vec3[2]
+        };
+        PARAM_UPDATE_INFO scaling_info = {
+            "scaling",
+            QVariant::fromValue(QVector<double>{1, 1, 1}),
+            QVariant::fromValue(scaling)
+        };
+        pModel->updateSocketDefl(new_node_id, scaling_info, subgraph_index, true);
+        auto rotate_vec3 = getRotateEulerVec();
+        QVector<double> rotate = {
+            rotate_vec3[0],
+            rotate_vec3[1],
+            rotate_vec3[2]
+        };
+        PARAM_UPDATE_INFO rotate_info = {
+            "eulerXYZ",
+            QVariant::fromValue(QVector<double>{0, 0, 0}),
+            QVariant::fromValue(rotate)
+        };
+        pModel->updateSocketDefl(new_node_id, rotate_info, subgraph_index, true);
+
+        if (change_visibility) {
+            // make node not visible
+            int old_option = node_index.data(ROLE_OPTIONS).toInt();
+            int new_option = old_option;
+            new_option ^= OPT_VIEW;
+            STATUS_UPDATE_INFO status_info = {old_option, new_option, ROLE_OPTIONS};
+            pModel->updateNodeStatus(node_id, status_info, subgraph_index, true);
+
+            // make new node visible
+            old_option = 0;
+            new_option = 0 | OPT_VIEW;
+            status_info.oldValue = old_option;
+            status_info.newValue = new_option;
+            pModel->updateNodeStatus(new_node_id, status_info, subgraph_index, true);
+        }
+    }
+
+    QVariant linkedToVisibleTransformNode(QModelIndex& node_index, IGraphsModel* pModel) const {
+        auto output_sockets = node_index.data(ROLE_OUTPUTS).value<OUTPUT_SOCKETS>();
+        auto linked_edges = output_sockets["prim"].linkIndice;
+        for (const auto& linked_edge : linked_edges) {
+            auto node_id = linked_edge.data(ROLE_INNODE).toString();
+            if (node_id.contains("TransformPrimitive")) {
+                auto search_result = pModel->search(node_id, SEARCH_NODEID);
+                auto linked_node_index = search_result[0].targetIdx;
+                auto option = linked_node_index.data(ROLE_OPTIONS).toInt();
+                if (option & OPT_VIEW) {
+                    return QVariant::fromValue(linked_node_index);
+                }
+            }
+        }
+        return {};
+    }
+
+    void syncToTransformNode(QString& node_id, IGraphsModel* pModel, QModelIndex& node_index, QModelIndex& subgraph_index) const {
+        auto inputs = node_index.data(ROLE_INPUTS).value<INPUT_SOCKETS>();
+        auto translate_old = inputs["translation"].info.defaultValue.value<UI_VECTYPE>();
+        QVector<double> translate_new(translate_old);
+        auto translate_offset = getTranslateVec();
+        for (int i=0; i<3; i++) {
+            translate_new[i] += translate_offset[i];
+        }
+        PARAM_UPDATE_INFO translate_info = {
+            "translation",
+            QVariant::fromValue(translate_old),
+            QVariant::fromValue(translate_new)
+        };
+        pModel->updateSocketDefl(node_id, translate_info, subgraph_index, true);
+        // update scaling
+        auto scaling_old = inputs["scaling"].info.defaultValue.value<UI_VECTYPE>();
+        QVector<double> scaling_new(scaling_old);
+        auto scaling_offset = getScaleVec();
+        for (int i=0; i<3; i++) {
+            scaling_new[i] *= scaling_offset[i];
+        }
+        PARAM_UPDATE_INFO scaling_info = {
+            "scaling",
+            QVariant::fromValue(scaling_old),
+            QVariant::fromValue(scaling_new)
+        };
+        pModel->updateSocketDefl(node_id, scaling_info, subgraph_index, true);
+        // update rotate
+        auto rotate_old = inputs["eulerXYZ"].info.defaultValue.value<UI_VECTYPE>();
+        QVector<double> rotate_new(rotate_old);
+        auto rotate_offset = getRotateEulerVec();
+        for (int i=0; i<3; i++) {
+            rotate_new[i] += rotate_offset[i];
+        }
+        PARAM_UPDATE_INFO rotate_info = {
+            "eulerXYZ",
+            QVariant::fromValue(rotate_old),
+            QVariant::fromValue(rotate_new)
+        };
+        pModel->updateSocketDefl(node_id, rotate_info, subgraph_index, true);
     }
 
     void startTransform() {
@@ -182,12 +324,16 @@ class FakeTransformer {
         status = false;
         translate_matrix = glm::mat4(1.0f);
         scale_matrix = glm::mat4(1.0f);
-        rotate_eular_vec = glm::vec3(1.0f);
+        rotate_eular_vec = glm::vec3(0.0f);
         Zenovis::GetInstance().getSession()->set_interactive(false);
     }
 
     bool isTransforming() const {
         return status;
+    }
+
+    int getOperation() const {
+        return operation;
     }
 
     glm::vec3 getCenter() {
@@ -263,76 +409,8 @@ class FakeTransformer {
     glm::vec3 objects_center;
 
     bool status;
+    int operation;
 };
-
-//void getTranslateTransformMatrix(glm::mat4 &matrix, QVector3D start, QVector3D end, QVector3D axis);
-//void getTranslateTransformMatrix(glm::mat4 &matrix, QVector3D start, QVector3D end, QVector3D axis) {
-//    auto diff = end - start;
-//    glm::vec3 diff_vec3 = QVec3ToGLMVec3(diff);
-//    diff_vec3 *= QVec3ToGLMVec3(axis);
-//    matrix = glm::translate(diff_vec3);
-//}
-//
-////void print_vec3(std::string name, glm::vec3 vec) {
-////    printf("%s: %.2lf, %.2lf, %.2lf // ", name.c_str(), vec[0], vec[1], vec[2]);
-////}
-//
-//void getRotateTransformMatrix(glm::mat4 &matrix, QVector3D start_vec, QVector3D end_vec, QVector3D axis);
-//void getRotateTransformMatrix(glm::mat4 &matrix, QVector3D start_vec, QVector3D end_vec, QVector3D axis) {
-//    glm::vec3 start_vec3 = QVec3ToGLMVec3(start_vec);
-//    glm::vec3 end_vec3 = QVec3ToGLMVec3(end_vec);
-//    glm::vec3 axis_vec3 = QVec3ToGLMVec3(axis);
-//    start_vec3 = glm::normalize(start_vec3);
-//    end_vec3 = glm::normalize(end_vec3);
-//    auto cross_vec3 = glm::cross(start_vec3, end_vec3);
-//    float direct = 1.0f;
-//    if (glm::dot(cross_vec3, axis_vec3) < 0)
-//        direct = -1.0f;
-//    float angle = acos(fmin(fmax(glm::dot(start_vec3, end_vec3), -1.0f), 1.0f));
-//    matrix = glm::rotate(angle * direct, axis_vec3);
-//}
-//
-//void getScaleTransformMatrix(glm::mat4 &matrix, QVector3D cur_vec, vec3i axis, float scale_size);
-//void getScaleTransformMatrix(glm::mat4 &matrix, QVector3D cur_vec, vec3i axis, float scale_size) {
-//    glm::vec3 cur_vec3 = QVec3ToGLMVec3(cur_vec);
-//    glm::vec3 scale(1.0f);
-//    for (int i=0; i<3; i++)
-//        if (axis[i] == 1) scale[i] = scale_size * 3;
-//    matrix = glm::scale(scale);
-//}
-//
-//void doFakeTransformPrimitive(zeno::PrimitiveObject *obj, glm::mat4 transform_matrix);
-//void doFakeTransformPrimitive(zeno::PrimitiveObject *obj, glm::mat4 const transform_matrix) {
-//
-//    if (obj->has_attr("pos")) {
-//        // transform pos
-//        auto &pos = obj->attr<zeno::vec3f>("pos");
-//        for (auto &po : pos) {
-//            auto p = zeno::vec_to_other<glm::vec3>(po);
-//            auto t = transform_matrix * glm::vec4(p, 1.0f);
-//            auto pt = glm::vec3(t) / t.w;
-//            po = zeno::other_to_vec<3>(pt);
-//        }
-//    }
-//    if (obj->has_attr("nrm")) {
-//        // transform nrm
-//        auto &nrm = obj->attr<zeno::vec3f>("nrm");
-//        for (auto &i : nrm) {
-//            auto n = zeno::vec_to_other<glm::vec3>(i);
-//            glm::mat3 norm_matrix(transform_matrix);
-//            norm_matrix = glm::transpose(glm::inverse(norm_matrix));
-//            auto t = glm::normalize(norm_matrix * n);
-//            i = zeno::other_to_vec<3>(n);
-//        }
-//    }
-//    auto &user_data = obj->userData();
-//    if (user_data.has("_bboxMin") && user_data.has("_bboxMax")) {
-//        vec3f bmin, bmax;
-//        std::tie(bmin, bmax) = primBoundingBox(obj);
-//        user_data.setLiterial("_bboxMin", bmin);
-//        user_data.setLiterial("_bboxMax", bmax);
-//    }
-//}
 
 }
 

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -19,7 +19,7 @@
 #include <util/log.h>
 #include <zenoui/style/zenostyle.h>
 //#include <zeno/utils/zeno_p.h>
-//#include <nodesys/nodesmgr.h>
+#include <nodesys/nodesmgr.h>
 #include <cmath>
 #include <algorithm>
 #include <optional>
@@ -83,6 +83,7 @@ CameraControl::CameraControl(QWidget* parent)
     , m_aperture(0.1f)
     , m_focalPlaneDistance(2.0f)
 {
+    transformer = std::make_unique<zeno::FakeTransformer>();
     updatePerspective();
 }
 
@@ -98,11 +99,51 @@ void CameraControl::fakeMousePressEvent(QMouseEvent* event)
     }
     else if (event->buttons() & Qt::LeftButton) {
         m_boundRectStartPos = event->pos();
+        m_lastPos = event->pos();
+        // check if clicked a selected object
+        auto scene = Zenovis::GetInstance().getSession()->get_scene();
+        if (!scene->selected.empty() && mouseEnteredRing(event->x(), event->y())) {
+            transformer->startTransform();
+        }
     }
+}
+
+QVector2D CameraControl::qtCoordToGLCoord(int x, int y) {
+    auto w = res()[0];
+    auto h = res()[1];
+    auto mx = x * 1.0f;
+    auto my = y * 1.0f;
+
+    mx = (2 * mx / w) - 1;
+    my = 1 - (2 * my / h);
+    return {mx, my};
+}
+
+bool CameraControl::mouseEnteredRing(int x, int y) {
+    auto scene = Zenovis::GetInstance().getSession()->get_scene();
+    auto world_coord = glm::vec4(transformer->getCenter(), 1.0);
+    auto screen_coord = scene->camera->m_proj * scene->camera->m_view * world_coord;
+    screen_coord /= screen_coord[3];
+
+    auto cx = screen_coord[0];
+    auto cy = screen_coord[1];
+
+    auto mp = qtCoordToGLCoord(x, y);
+    auto mx = mp.x();
+    auto my = mp.y();
+
+    auto ar = res()[0] / res()[1];
+
+    auto dis = sqrt(((cx - mx) * ar) * ((cx - mx) * ar) + (cy - my) * (cy - my));
+    // 0.1 is the bigger radius of ring
+    return dis < 0.1;
 }
 
 void CameraControl::fakeMouseMoveEvent(QMouseEvent* event)
 {
+    auto session = Zenovis::GetInstance().getSession();
+    auto scene = session->get_scene();
+
     if (event->buttons() & Qt::MiddleButton) {
         float ratio = QApplication::desktop()->devicePixelRatio();
         float xpos = event->x(), ypos = event->y();
@@ -133,12 +174,262 @@ void CameraControl::fakeMouseMoveEvent(QMouseEvent* event)
         m_lastPos = QPointF(xpos, ypos);
     }
     else if (event->buttons() & Qt::LeftButton) {
-        auto scene = Zenovis::GetInstance().getSession()->get_scene();
-        float min_x = std::min((float)m_boundRectStartPos.x(), (float)event->x()) / m_res.x();
-        float max_x = std::max((float)m_boundRectStartPos.x(), (float)event->x()) / m_res.x();
-        float min_y = std::min((float)m_boundRectStartPos.y(), (float)event->y()) / m_res.y();
-        float max_y = std::max((float)m_boundRectStartPos.y(), (float)event->y()) / m_res.y();
-        scene->select_box = zeno::vec4f(min_x, min_y, max_x, max_y);
+        if (transformer->isTransforming()) {
+            bool alt_pressed = event->modifiers() & Qt::AltModifier;
+            bool ctrl_pressed = event->modifiers() & Qt::ControlModifier;
+            bool shift_pressed = event->modifiers() & Qt::ShiftModifier;
+            glm::mat4 transform_matrix(1.0f);
+
+            auto transform_center = transformer->getCenter();
+            QVector3D center_qvec(transform_center[0], transform_center[1], transform_center[2]);
+            zeno::vec3f center_zvec(transform_center[0], transform_center[1], transform_center[2]);
+
+            std::set<std::unique_ptr<zenovis::IGraphicDraw>> interactingGraphics;
+            QVector3D x_axis(1, 0, 0);
+            QVector3D y_axis(0, 1, 0);
+            QVector3D z_axis(0, 0, 1);
+
+            QVariant start, end;
+            QVector3D start_vec, end_vec;
+            // get transform matrix
+            if (ctrl_pressed && alt_pressed) {
+                // rotate
+                if (m_pressedKeys.contains(Qt::Key_Z)) {
+                    // rotate along x=center_qvec.x plane
+                    start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                       x_axis, center_qvec);
+                    end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                     x_axis, center_qvec);
+                    if (start.isValid() && end.isValid()) {
+                        start_vec = start.value<QVector3D>() - center_qvec;
+                        end_vec = end.value<QVector3D>() - center_qvec;
+                        transformer->rotate(start_vec, end_vec, x_axis);
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 0, 0}));
+                    }
+                }
+                else if (m_pressedKeys.contains(Qt::Key_X)) {
+                    // rotate along y=center_qvec.y plane
+                    start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                       y_axis, center_qvec);
+                    end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                     y_axis, center_qvec);
+                    if (start.isValid() && end.isValid()) {
+                        start_vec = start.value<QVector3D>() - center_qvec;
+                        end_vec = end.value<QVector3D>() - center_qvec;
+                        transformer->rotate(start_vec, end_vec, y_axis);
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 1, 0}));
+                    }
+                }
+                else if (m_pressedKeys.contains(Qt::Key_C)) {
+                    // rotate along z=center_qvec.z plane
+                    start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                       z_axis, center_qvec);
+                    end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                     z_axis, center_qvec);
+                    if (start.isValid() && end.isValid()) {
+                        start_vec = start.value<QVector3D>() - center_qvec;
+                        end_vec = end.value<QVector3D>() - center_qvec;
+                        transformer->rotate(start_vec, end_vec, z_axis);
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 0, 1}));
+                    }
+                }
+            }
+            else if (alt_pressed) {
+                // scale
+                auto vp = scene->camera->m_proj * scene->camera->m_view;
+                auto screen_center = vp * glm::vec4(transform_center, 1.0f);
+                screen_center /= screen_center[3];
+                QVector2D screen_center_2d(screen_center[0], screen_center[1]);
+                QVector2D mouse_pos = qtCoordToGLCoord(event->x(), event->y());
+                float scale_size = mouse_pos.distanceToPoint(screen_center_2d);
+                // printf("%.2lf\n", scale_size);
+
+                if (m_pressedKeys.contains(Qt::Key_A)) {
+                    // scale along a plane
+                    if (m_pressedKeys.contains(Qt::Key_Z)) {
+                        // scale along x=center_qvec.x plane
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              y_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{0, 1, 1}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec,{0, 1, 1}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_X)) {
+                        // scale along y=center_qvec.y plane
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              y_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{1, 0, 1}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 0, 1}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_C)) {
+                        // scale along z=center_qvec.z plane
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              z_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{1, 1, 0}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 1, 0}));
+                    }
+                }
+                else {
+                    // scale along an axis
+                    if (m_pressedKeys.contains(Qt::Key_Z)) {
+                        // scale along x axis
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              y_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{1, 0, 0}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 0, 0}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_X)) {
+                        // scale along y=center_qvec.y plane
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              y_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{0, 1, 0}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 1, 0}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_C)) {
+                        auto cur = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                              z_axis, center_qvec);
+                        if (cur.isValid()) {
+                            transformer->scale(cur.value<QVector3D>() - center_qvec,{0, 0, 1}, scale_size);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 0, 1}));
+                    }
+                }
+            }
+            else if (ctrl_pressed){
+                // translate
+                if (m_pressedKeys.contains(Qt::Key_A)) {
+                    // translate along a plane
+                    if (m_pressedKeys.contains(Qt::Key_Z)) {
+                        // translate along x=center_qvec.x plane
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           x_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         x_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),
+                                                   end.value<QVector3D>(), {0, 1, 1});
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec,{0, 1, 1}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_X)) {
+                        // translate along y=center_qvec.y plane
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           y_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         y_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),
+                                                   end.value<QVector3D>(), {1, 0, 1});
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 0, 1}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_C)) {
+                        // translate along z=center_qvec.z plane
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           z_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         z_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),
+                                                   end.value<QVector3D>(), {1, 1, 0});
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 1, 0}));
+                    }
+                }
+                else {
+                    // translate along an axis
+                    QVector3D translate_axis;
+                    if (m_pressedKeys.contains(Qt::Key_Z)) {
+                        // translate along x axis
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           y_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         y_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),end.value<QVector3D>(), x_axis);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {1, 0, 0}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_X)) {
+                        // translate along y=center_qvec.y plane
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           z_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         z_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),end.value<QVector3D>(), y_axis);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 1, 0}));
+                    }
+                    else if (m_pressedKeys.contains(Qt::Key_C)) {
+                        // translate along z=center_qvec.z plane
+                        start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                           y_axis, center_qvec);
+                        end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                         y_axis, center_qvec);
+                        if (start.isValid() && end.isValid()) {
+                            transformer->translate(start.value<QVector3D>(),end.value<QVector3D>(), z_axis);
+                        }
+                        interactingGraphics.insert(
+                            zenovis::makeGraphicInteractingAxis(scene, center_zvec, {0, 0, 1}));
+                    }
+                }
+            }
+            else {
+                // free translate (along sight plane)
+                QVector3D camera_front(scene->camera->m_lodfront[0],
+                                       scene->camera->m_lodfront[1],
+                                       scene->camera->m_lodfront[2]);
+                start = hitOnPlane((float)m_lastPos.x() / res().x(), (float)m_lastPos.y() / res().y(),
+                                   camera_front, center_qvec);
+                end = hitOnPlane((float)event->x() / res().x(), (float)event->y() / res().y(),
+                                 camera_front, center_qvec);
+                if (start.isValid() && end.isValid()) {
+                    transformer->translate(start.value<QVector3D>(),end.value<QVector3D>(), {1, 1, 1});
+                }
+            }
+            session->set_interacting_graphics(interactingGraphics);
+            m_lastPos = event->pos();
+            zenoApp->getMainWindow()->updateViewport();
+        }
+        else {
+            float min_x = std::min((float)m_boundRectStartPos.x(), (float)event->x()) / m_res.x();
+            float max_x = std::max((float)m_boundRectStartPos.x(), (float)event->x()) / m_res.x();
+            float min_y = std::min((float)m_boundRectStartPos.y(), (float)event->y()) / m_res.y();
+            float max_y = std::max((float)m_boundRectStartPos.y(), (float)event->y()) / m_res.y();
+            scene->select_box = zeno::vec4f(min_x, min_y, max_x, max_y);
+        }
+    }
+    else {
+        if (mouseEnteredRing(event->x(), event->y())) {
+            Zenovis::GetInstance().getSession()->set_hovered_graphic("ring");
+        }
+        else {
+            Zenovis::GetInstance().getSession()->set_hovered_graphic("");
+        }
     }
     updatePerspective();
 }
@@ -236,112 +527,270 @@ QVariant CameraControl::hitOnFloor(float x, float y) const {
         return {};
     }
 }
+
+QVariant CameraControl::hitOnPlane(float x, float y, QVector3D n, QVector3D p) const {
+    auto dir = screenToWorldRay(x, y);
+    auto pos = realPos();
+    float t = (n.x()*p.x() + n.y()*p.y() + n.z()*p.z() - n.x()*pos.x() - n.y()*pos.y() - n.z()*pos.z()) /
+              (n.x()*dir.x() + n.y()*dir.y() + n.z()*dir.z());
+    if (t > 0)
+        return pos + dir * t;
+    else
+        return {};
+}
+
 void CameraControl::fakeMouseReleaseEvent(QMouseEvent *event) {
     if (event->button() == Qt::LeftButton) {
 
         
         //if (Zenovis::GetInstance().m_bAddPoint == true) {
-            //float x = (float)event->x() / m_res.x();
-            //float y = (float)event->y() / m_res.y();
-            //auto rdir = screenToWorldRay(x, y);
-            //auto pos = realPos();
-            //float t = (0 - pos.y()) / rdir.y();
-            //auto p = pos + rdir * t;
+        //float x = (float)event->x() / m_res.x();
+        //float y = (float)event->y() / m_res.y();
+        //auto rdir = screenToWorldRay(x, y);
+        //auto pos = realPos();
+        //float t = (0 - pos.y()) / rdir.y();
+        //auto p = pos + rdir * t;
 
-            //float cos_t = std::cos(m_theta);
-            //float sin_t = std::sin(m_theta);
-            //float cos_p = std::cos(m_phi);
-            //float sin_p = std::sin(m_phi);
-            //QVector3D back(cos_t * sin_p, sin_t, -cos_t * cos_p);
-            //QVector3D up(-sin_t * sin_p, cos_t, sin_t * cos_p);
-            //QVector3D right = QVector3D::crossProduct(up, back).normalized();
-            //up = QVector3D::crossProduct(right, back).normalized();
-            //QVector3D delta = right * x + up * y;
+        //float cos_t = std::cos(m_theta);
+        //float sin_t = std::sin(m_theta);
+        //float cos_p = std::cos(m_phi);
+        //float sin_p = std::sin(m_phi);
+        //QVector3D back(cos_t * sin_p, sin_t, -cos_t * cos_p);
+        //QVector3D up(-sin_t * sin_p, cos_t, sin_t * cos_p);
+        //QVector3D right = QVector3D::crossProduct(up, back).normalized();
+        //up = QVector3D::crossProduct(right, back).normalized();
+        //QVector3D delta = right * x + up * y;
                 
             
-            //zeno::log_info("create point at x={} y={}", p[0], p[1]);
+        //zeno::log_info("create point at x={} y={}", p[0], p[1]);
 
-            ////createPointNode(QPointF(p[0], p[1]));
+        ////createPointNode(QPointF(p[0], p[1]));
 
-            //Zenovis::GetInstance().m_bAddPoint = false;
+        //Zenovis::GetInstance().m_bAddPoint = false;
         //}
 
-        auto cam_pos = realPos();
         auto scene = Zenovis::GetInstance().getSession()->get_scene();
-        scene->select_box = std::nullopt;
-        bool shift_pressed = event->modifiers() & Qt::ShiftModifier;
-        if (!shift_pressed) {
-            scene->selected.clear();
-        }
 
-        QPoint releasePos = event->pos();
-        if (m_boundRectStartPos == releasePos) {
-            float x = (float)event->x() / m_res.x();
-            float y = (float)event->y() / m_res.y();
-            auto rdir = screenToWorldRay(x, y);
-            float min_t = std::numeric_limits<float>::max();
-            std::string name("");
-            for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
-                zeno::vec3f center;
-                float radius;
-                zeno::vec3f ro(cam_pos[0], cam_pos[1], cam_pos[2]);
-                zeno::vec3f rd(rdir[0], rdir[1], rdir[2]);
-                if (zeno::objectGetFocusCenterRadius(ptr, center, radius)) {
-                    if (auto ret = ray_sphere_intersect(ro, rd, center, radius)) {
-                        float t = *ret;
-                        if (t < min_t) {
-                            min_t = t;
-                            name = key;
+        if (transformer->isTransforming()) {
+            if (m_boundRectStartPos != event->pos()) {
+                // todo create/modify transform primitive node
+                IGraphsModel* pModel = zenoApp->graphsManagment()->currentModel();
+                for (const auto &obj_name : scene->selected) {
+                    QString node_id(obj_name.substr(0, obj_name.find_first_of(':')).c_str());
+                    auto search_result = pModel->search(node_id, SEARCH_NODEID);
+                    const auto subgraph_index = search_result[0].subgIdx;
+                    auto node_index = search_result[0].targetIdx;
+                    auto inputs = node_index.data(ROLE_INPUTS).value<INPUT_SOCKETS>();
+                    if (obj_name.find("TransformPrimitive") != std::string::npos &&
+                        inputs["translation"].linkIndice.empty() &&
+                        inputs["eulerXYZ"].linkIndice.empty() &&
+                        inputs["scaling"].linkIndice.empty()) {
+                        auto translate_old = inputs["translation"].info.defaultValue.value<UI_VECTYPE>();
+                        QVector<double> translate_new(translate_old);
+                        auto translate_offset = transformer->getTranslateVec();
+                        for (int i=0; i<3; i++) {
+                            translate_new[i] += translate_offset[i];
+                        }
+                        PARAM_UPDATE_INFO translate_info = {
+                            "translation",
+                            QVariant::fromValue(translate_old),
+                            QVariant::fromValue(translate_new)
+                        };
+                        pModel->updateSocketDefl(node_id, translate_info, subgraph_index, true);
+                        // update scaling
+                        auto scaling_old = inputs["scaling"].info.defaultValue.value<UI_VECTYPE>();
+                        QVector<double> scaling_new(scaling_old);
+                        auto scaling_offset = transformer->getScaleVec();
+                        for (int i=0; i<3; i++) {
+                            scaling_new[i] *= scaling_offset[i];
+                        }
+                        PARAM_UPDATE_INFO scaling_info = {
+                            "scaling",
+                            QVariant::fromValue(scaling_old),
+                            QVariant::fromValue(scaling_new)
+                        };
+                        pModel->updateSocketDefl(node_id, scaling_info, subgraph_index, true);
+                        // update rotate
+                        auto rotate_old = inputs["eulerXYZ"].info.defaultValue.value<UI_VECTYPE>();
+                        QVector<double> rotate_new(rotate_old);
+                        auto rotate_offset = transformer->getRotateEulerVec();
+                        for (int i=0; i<3; i++) {
+                            rotate_new[i] += rotate_offset[i];
+                        }
+                        PARAM_UPDATE_INFO rotate_info = {
+                            "eulerXYZ",
+                            QVariant::fromValue(rotate_old),
+                            QVariant::fromValue(rotate_new)
+                        };
+                        pModel->updateSocketDefl(node_id, rotate_info, subgraph_index, true);
+                    }
+                    else {
+                        auto pos = node_index.data(ROLE_OBJPOS).toPointF();
+                        pos.setX(pos.x() + 10);
+                        auto new_node_id = NodesMgr::createNewNode(pModel, subgraph_index, "TransformPrimitive", pos);
+                        EdgeInfo edge = {
+                            node_id,
+                            new_node_id,
+                            "prim",
+                            "prim"
+                        };
+                        pModel->addLink(edge, subgraph_index, false);
+
+                        auto translate_vec3 = transformer->getTranslateVec();
+                        QVector<double> translate = {
+                            translate_vec3[0],
+                            translate_vec3[1],
+                            translate_vec3[2]
+                        };
+                        PARAM_UPDATE_INFO translate_info = {
+                            "translation",
+                            QVariant::fromValue(QVector<double>{0, 0, 0}),
+                            QVariant::fromValue(translate)
+                        };
+                        pModel->updateSocketDefl(new_node_id, translate_info, subgraph_index, true);
+                        auto scaling_vec3 = transformer->getScaleVec();
+                        QVector<double> scaling = {
+                            scaling_vec3[0],
+                            scaling_vec3[1],
+                            scaling_vec3[2]
+                        };
+                        PARAM_UPDATE_INFO scaling_info = {
+                            "scaling",
+                            QVariant::fromValue(QVector<double>{1, 1, 1}),
+                            QVariant::fromValue(scaling)
+                        };
+                        pModel->updateSocketDefl(new_node_id, scaling_info, subgraph_index, true);
+                        auto rotate_vec3 = transformer->getRotateEulerVec();
+                        QVector<double> rotate = {
+                            rotate_vec3[0],
+                            rotate_vec3[1],
+                            rotate_vec3[2]
+                        };
+                        PARAM_UPDATE_INFO rotate_info = {
+                            "eulerXYZ",
+                            QVariant::fromValue(QVector<double>{0, 0, 0}),
+                            QVariant::fromValue(rotate)
+                        };
+                        pModel->updateSocketDefl(new_node_id, rotate_info, subgraph_index, true);
+
+                        int old_option = node_index.data(ROLE_OPTIONS).toInt();
+                        int new_option = old_option;
+                        new_option ^= OPT_VIEW;
+                        STATUS_UPDATE_INFO status_info = {
+                            old_option,
+                            new_option,
+                            ROLE_OPTIONS
+                        };
+                        pModel->updateNodeStatus(node_id, status_info, subgraph_index, true);
+
+                        old_option = 0;
+                        new_option = 0 | OPT_VIEW;
+                        status_info.oldValue = old_option;
+                        status_info.newValue = new_option;
+                        pModel->updateNodeStatus(new_node_id, status_info, subgraph_index, true);
+                    }
+
+                }
+            }
+            transformer->endTransform();
+        }
+        else {
+            auto cam_pos = realPos();
+
+            scene->select_box = std::nullopt;
+            bool shift_pressed = event->modifiers() & Qt::ShiftModifier;
+            if (!shift_pressed) {
+                scene->selected.clear();
+                transformer->clear();
+            }
+
+            QPoint releasePos = event->pos();
+            if (m_boundRectStartPos == releasePos) {
+                float x = (float)event->x() / m_res.x();
+                float y = (float)event->y() / m_res.y();
+                auto rdir = screenToWorldRay(x, y);
+                float min_t = std::numeric_limits<float>::max();
+                std::string name("");
+                for (auto const &[key, ptr] : scene->objectsMan->pairs()) {
+                    zeno::vec3f center;
+                    float radius;
+                    zeno::vec3f ro(cam_pos[0], cam_pos[1], cam_pos[2]);
+                    zeno::vec3f rd(rdir[0], rdir[1], rdir[2]);
+                    if (zeno::objectGetFocusCenterRadius(ptr, center, radius)) {
+                        if (auto ret = ray_sphere_intersect(ro, rd, center, radius)) {
+                            float t = *ret;
+                            if (t < min_t) {
+                                min_t = t;
+                                name = key;
+                            }
                         }
                     }
                 }
-            }
-            if (!name.empty()) {
-                if (scene->selected.count(name) > 0) {
-                    scene->selected.erase(name);
-                } else {
-                    scene->selected.insert(name);
-                }
-            }
-        }
-        else {
-            float min_x = std::min((float)m_boundRectStartPos.x(), (float)releasePos.x());
-            float max_x = std::max((float)m_boundRectStartPos.x(), (float)releasePos.x());
-            float min_y = std::min((float)m_boundRectStartPos.y(), (float)releasePos.y());
-            float max_y = std::max((float)m_boundRectStartPos.y(), (float)releasePos.y());
-            auto left_up    = screenToWorldRay(min_x / m_res.x(), min_y / m_res.y());
-            auto left_down  = screenToWorldRay(min_x / m_res.x(), max_y / m_res.y());
-            auto right_up   = screenToWorldRay(max_x / m_res.x(), min_y / m_res.y());
-            auto right_down = screenToWorldRay(max_x / m_res.x(), max_y / m_res.y());
-            auto cam_posWS = realPos();
-            auto left_normWS  = QVector3D::crossProduct(left_down, left_up);
-            auto right_normWS = QVector3D::crossProduct(right_up, right_down);
-            auto up_normWS    = QVector3D::crossProduct(left_up, right_up);
-            auto down_normWS  = QVector3D::crossProduct(right_down, left_down);
-
-            std::vector<std::string> passed_prim;
-            for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
-                zeno::vec3f c;
-                float radius;
-                if (zeno::objectGetFocusCenterRadius(ptr, c, radius)) {
-                    bool passed = test_in_selected_bounding(
-                        QVector3D(c[0], c[1], c[2]),
-                        cam_pos,
-                        left_normWS,
-                        right_normWS,
-                        up_normWS,
-                        down_normWS
-                    );
-                    if (passed) {
-                        passed_prim.push_back(key);
+                if (!name.empty()) {
+                    if (scene->selected.count(name) > 0) {
+                        scene->selected.erase(name);
+                        transformer->removeObject(name);
+                    } else {
+                        scene->selected.insert(name);
+                        transformer->addObject(name);
+                        // printf("selected %s\n", name.c_str());
                     }
                 }
+            } else {
+                float min_x = std::min((float)m_boundRectStartPos.x(), (float)releasePos.x());
+                float max_x = std::max((float)m_boundRectStartPos.x(), (float)releasePos.x());
+                float min_y = std::min((float)m_boundRectStartPos.y(), (float)releasePos.y());
+                float max_y = std::max((float)m_boundRectStartPos.y(), (float)releasePos.y());
+                auto left_up = screenToWorldRay(min_x / m_res.x(), min_y / m_res.y());
+                auto left_down = screenToWorldRay(min_x / m_res.x(), max_y / m_res.y());
+                auto right_up = screenToWorldRay(max_x / m_res.x(), min_y / m_res.y());
+                auto right_down = screenToWorldRay(max_x / m_res.x(), max_y / m_res.y());
+                auto cam_posWS = realPos();
+                auto left_normWS = QVector3D::crossProduct(left_down, left_up);
+                auto right_normWS = QVector3D::crossProduct(right_up, right_down);
+                auto up_normWS = QVector3D::crossProduct(left_up, right_up);
+                auto down_normWS = QVector3D::crossProduct(right_down, left_down);
+
+                std::vector<std::string> passed_prim;
+                for (auto const &[key, ptr] : scene->objectsMan->pairs()) {
+                    zeno::vec3f c;
+                    float radius;
+                    if (zeno::objectGetFocusCenterRadius(ptr, c, radius)) {
+                        bool passed = test_in_selected_bounding(QVector3D(c[0], c[1], c[2]), cam_pos, left_normWS,
+                                                                right_normWS, up_normWS, down_normWS);
+                        if (passed) {
+                            passed_prim.push_back(key);
+                            transformer->addObject(key);
+                        }
+                    }
+                }
+                scene->selected.insert(passed_prim.begin(), passed_prim.end());
+
             }
-            scene->selected.insert(passed_prim.begin(), passed_prim.end());
         }
+
+        if (!scene->selected.empty()) {
+            auto center = transformer->getCenter();
+            zeno::vec3f ring_center(center[0], center[1], center[2]);
+            std::map<std::string, std::unique_ptr<zenovis::IGraphicInteractDraw>> interactGraphics;
+            interactGraphics["ring"] = zenovis::makeGraphicRing(scene, ring_center);
+            interactGraphics["axis"] = zenovis::makeGraphicInteractAxis(scene, ring_center);
+            Zenovis::GetInstance().getSession()->set_interactive_graphics(interactGraphics);
+
+            zenoApp->getMainWindow()->updateViewport();
+        }
+
         ZenoMainWindow* mainWin = zenoApp->getMainWindow();
         mainWin->onPrimitiveSelected(scene->selected);
     }
+}
+
+void CameraControl::addPressedKey(int key) {
+    m_pressedKeys += key;
+}
+
+void CameraControl::rmvPressedKey(int key) {
+    m_pressedKeys -= key;
 }
 
 //void CameraControl::createPointNode(QPointF pnt) {
@@ -496,8 +945,16 @@ void ViewportWidget::mouseReleaseEvent(QMouseEvent *event) {
     update();
 }
 
+void ViewportWidget::addPressedKey(int key) {
+    m_camera->addPressedKey(key);
+}
+
+void ViewportWidget::rmvPressedKey(int key) {
+    m_camera->rmvPressedKey(key);
+}
+
 /*
-QDMDisplayMenu::QDMDisplayMenu()
+QDMDisplayMenu::QDMDisplayMenu()r("Show Grid")
 {
     setTitle(tr("Display"));
     QAction* pAction = new QAction(tr("Show Grid"), this);
@@ -585,6 +1042,7 @@ DisplayWidget::DisplayWidget(ZenoMainWindow* pMainWin)
     */
 
     m_view = new ViewportWidget;
+    m_view->setMouseTracking(true);
     pLayout->addWidget(m_view);
 
     m_timeline = new ZTimeline;
@@ -758,6 +1216,17 @@ void DisplayWidget::onRun()
     auto scene = Zenovis::GetInstance().getSession()->get_scene();
     scene->objectsMan->lightObjects.clear();
 }
+
+void DisplayWidget::keyPressEvent(QKeyEvent* event) {
+    if (!event->isAutoRepeat())
+        m_view->addPressedKey(event->key());
+}
+
+void DisplayWidget::keyReleaseEvent(QKeyEvent* event) {
+    if (!event->isAutoRepeat())
+        m_view->rmvPressedKey(event->key());
+}
+
 
 void DisplayWidget::onRecord()
 {

--- a/ui/zenoedit/viewport/viewportwidget.h
+++ b/ui/zenoedit/viewport/viewportwidget.h
@@ -6,6 +6,9 @@
 #include "comctrl/zmenubar.h"
 #include "comctrl/zmenu.h"
 #include "common.h"
+#include "viewporttransform.h"
+
+#include <glm/glm.hpp>
 
 class ZTimeline;
 class ZenoMainWindow;
@@ -57,6 +60,11 @@ public:
     QVector3D realPos() const;
     QVector3D screenToWorldRay(float x, float y) const;
     QVariant hitOnFloor(float x, float y) const;
+    QVariant hitOnPlane(float x, float y, QVector3D n, QVector3D p) const;
+    QVector2D qtCoordToGLCoord(int x, int y);
+    bool mouseEnteredRing(int x, int y);
+    void addPressedKey(int key);
+    void rmvPressedKey(int key);
 
 
 private:
@@ -72,6 +80,9 @@ private:
     float m_aperture;
     float m_focalPlaneDistance;
     QVector2D m_res;
+
+    QSet<int> m_pressedKeys;
+    std::unique_ptr<zeno::FakeTransformer> transformer;
 };
 
 class ViewportWidget : public QOpenGLWidget
@@ -88,6 +99,8 @@ public:
     QVector2D cameraRes() const;
     void setCameraRes(const QVector2D& res);
     void updatePerspective();
+    void addPressedKey(int key);
+    void rmvPressedKey(int key);
 
 
 signals:
@@ -134,6 +147,10 @@ public slots:
 
 signals:
     void frameUpdated(int new_frame);
+
+  protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
 
 private:
     bool isOptxRendering() const;

--- a/zenovis/include/zenovis/DrawOptions.h
+++ b/zenovis/include/zenovis/DrawOptions.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <zenovis/bate/IGraphic.h>
+
 #include <array>
+#include <set>
 #include <glm/vec3.hpp>
 
 namespace zenovis {
@@ -13,6 +16,12 @@ struct DrawOptions {
     bool smooth_shading = false;
     bool normal_check = false;
     int num_samples = 16;
+
+    bool interactive = false;
+    std::string hovered_graphic_id;
+    std::map<std::string, std::unique_ptr<IGraphicInteractDraw>> interactGraphics;
+
+    std::set<std::unique_ptr<IGraphicDraw>> interactingGraphics;
 
     glm::vec3 bgcolor{0.23f, 0.23f, 0.23f};
 };

--- a/zenovis/include/zenovis/Session.h
+++ b/zenovis/include/zenovis/Session.h
@@ -5,10 +5,12 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <set>
 #include <zeno/core/IObject.h>
 #include <zeno/utils/disable_copy.h>
 #include <zeno/utils/vec.h>
 #include <zenovis/Scene.h>
+#include <zenovis/bate/IGraphic.h>
 
 namespace zenovis {
 
@@ -39,6 +41,10 @@ struct Session : zeno::disable_copy {
     void set_normal_check(bool check);
     void set_render_wireframe(bool render_wireframe);
     void set_render_engine(std::string const &name);
+    void set_interactive(bool interactive);
+    void set_hovered_graphic(std::string hovered_graphic_id);
+    void set_interactive_graphics(std::map<std::string, std::unique_ptr<IGraphicInteractDraw>> &interactGraphics);
+    void set_interacting_graphics(std::set<std::unique_ptr<IGraphicDraw>> &interactGraphics);
     bool focus_on_node(std::string const &nodeid, zeno::vec3f &center, float &radius);
     static void load_opengl_api(void *procaddr);
     Scene* get_scene() const;

--- a/zenovis/include/zenovis/bate/IGraphic.h
+++ b/zenovis/include/zenovis/bate/IGraphic.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <zeno/core/IObject.h>
 #include <zeno/types/IObjectXMacro.h>
+#include <zeno/utils/vec.h>
 
 
 namespace zeno {
@@ -27,6 +28,10 @@ struct IGraphicDraw : IGraphic {
     virtual void draw() = 0;
 };
 
+struct IGraphicInteractDraw : IGraphicDraw {
+    virtual void setHovered(bool hovered) = 0;
+};
+
 struct MakeGraphicVisitor {
     Scene *in_scene{};
     std::unique_ptr<IGraphic> out_result;
@@ -42,4 +47,8 @@ std::unique_ptr<IGraphicDraw> makeGraphicAxis(Scene *scene);
 std::unique_ptr<IGraphicDraw> makeGraphicGrid(Scene *scene);
 std::unique_ptr<IGraphicDraw> makeGraphicSelectBox(Scene *scene);
 
+std::unique_ptr<IGraphicInteractDraw> makeGraphicRing(Scene *scene, zeno::vec3f center);
+std::unique_ptr<IGraphicInteractDraw> makeGraphicInteractAxis(Scene *scene, zeno::vec3f center) ;
+
+std::unique_ptr<IGraphicDraw> makeGraphicInteractingAxis(Scene *scene, zeno::vec3f center, zeno::vec3i axis);
 } // namespace zenovis

--- a/zenovis/src/Session.cpp
+++ b/zenovis/src/Session.cpp
@@ -165,6 +165,22 @@ void Session::set_render_engine(std::string const &name) {
     impl->scene->switchRenderEngine(name);
 }
 
+void Session::set_interactive(bool interactive) {
+    impl->scene->drawOptions->interactive = interactive;
+}
+
+void Session::set_hovered_graphic(std::string hovered_graphic_id) {
+    impl->scene->drawOptions->hovered_graphic_id = std::move(hovered_graphic_id);
+}
+
+void Session::set_interactive_graphics(std::map<std::string, std::unique_ptr<IGraphicInteractDraw>> &interactGraphics) {
+    std::swap(impl->scene->drawOptions->interactGraphics, interactGraphics);
+}
+
+void Session::set_interacting_graphics(std::set<std::unique_ptr<IGraphicDraw>> &interactingGraphics) {
+    std::swap(impl->scene->drawOptions->interactingGraphics, interactingGraphics);
+}
+
 void Session::load_opengl_api(void *procaddr) {
     Scene::loadGLAPI(procaddr);
 }

--- a/zenovis/src/bate/InteractGraphicAxis.cpp
+++ b/zenovis/src/bate/InteractGraphicAxis.cpp
@@ -1,0 +1,165 @@
+#include <zeno/utils/vec.h>
+#include <zenovis/Camera.h>
+#include <zenovis/Scene.h>
+#include <zenovis/bate/IGraphic.h>
+#include <zenovis/ShaderManager.h>
+#include <zenovis/opengl/buffer.h>
+#include <zenovis/opengl/shader.h>
+#include <zenovis/opengl/scope.h>
+#include <glm/glm.hpp>
+
+namespace zenovis {
+namespace {
+
+using opengl::Buffer;
+using opengl::Program;
+using zeno::vec3f;
+
+static const char *vert_code = R"(
+    #version 120
+
+    uniform mat4 mVP;
+    uniform mat4 mInvVP;
+    uniform mat4 mView;
+    uniform mat4 mProj;
+    uniform mat4 mInvView;
+    uniform mat4 mInvProj;
+
+    uniform mat4 mScale;
+
+    attribute vec3 vPosition;
+    attribute vec3 vColor;
+
+    varying vec3 position;
+    varying vec3 color;
+
+    void main() {
+        position = vPosition;
+        color = vColor;
+
+        gl_Position = mVP * vec4(position, 1.0);
+    }
+)";
+
+static const char *frag_code = R"(
+    #version 120
+
+    uniform mat4 mVP;
+    uniform mat4 mInvVP;
+    uniform mat4 mView;
+    uniform mat4 mProj;
+    uniform mat4 mInvView;
+    uniform mat4 mInvProj;
+
+    varying vec3 position;
+    varying vec3 color;
+
+    void main() {
+        gl_FragColor = vec4(color, 1.0);
+    }
+)";
+
+struct GraphicInteractAxis final : IGraphicInteractDraw {
+    Scene *scene;
+
+    std::unique_ptr<Buffer> vbo;
+    size_t vertex_count;
+
+    vec3f center;
+    bool hover;
+
+    Program *lines_prog;
+    std::unique_ptr<Buffer> lines_ebo;
+    size_t lines_count;
+
+    explicit GraphicInteractAxis(Scene *scene_, vec3f &center_)
+        : scene(scene_), center(center_), hover(false) {
+        vbo = std::make_unique<Buffer>(GL_ARRAY_BUFFER);
+    }
+
+    virtual void draw() override {
+        std::vector<zeno::vec3f> mem;
+
+        float cx = scene->camera->m_zxx.cx;
+        float cy = scene->camera->m_zxx.cy;
+        float cz = scene->camera->m_zxx.cz;
+        float theta = scene->camera->m_zxx.theta;
+        float phi = scene->camera->m_zxx.phi;
+        float radius = scene->camera->m_zxx.radius;
+
+        auto camera_center = glm::vec3(cx, cy, cz);
+        float cos_t = glm::cos(theta), sin_t = glm::sin(theta);
+        float cos_p = glm::cos(phi), sin_p = glm::sin(phi);
+        glm::vec3 front(cos_t * sin_p, sin_t, -cos_t * cos_p);
+
+        auto camera_pos = camera_center - front * radius;
+
+        auto dist = glm::distance(camera_pos, glm::vec3(center[0], center[1], center[2]));
+
+        float bound = dist / 10;
+
+        vec3f r = vec3f(0.8, 0.2, 0.2);
+        vec3f g = vec3f(0.2, 0.6, 0.2);
+        vec3f b = vec3f(0.2, 0.2, 0.8);
+
+        auto [x, y, z] = center;
+
+        mem.push_back(center);
+        mem.push_back(r);
+        mem.emplace_back(x + bound, y, z);
+        mem.push_back(r);
+
+        mem.push_back(center);
+        mem.push_back(g);
+        mem.emplace_back(x, y + bound, z);
+        mem.push_back(g);
+
+        mem.push_back(center);
+        mem.push_back(b);
+        mem.emplace_back(x, y, z + bound);
+        mem.push_back(b);
+
+        vertex_count = mem.size() / 2;
+        lines_count = vertex_count / 2;
+
+        vbo->bind_data(mem.data(), mem.size() * sizeof(mem[0]));
+
+        lines_prog = scene->shaderMan->compile_program(vert_code, frag_code);
+
+        vbo->bind();
+        vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 6, GL_FLOAT, 3);
+        vbo->attribute(1, sizeof(float) * 3, sizeof(float) * 6, GL_FLOAT, 3);
+
+        lines_prog->use();
+        scene->camera->set_program_uniforms(lines_prog);
+
+//        float scale_factor = 1 / scene->camera->m_zxx.radius;
+//        glm::mat4 scale_mat = glm::mat4(1.0f);
+//        scale_mat = glm::scale(scale_mat, glm::vec3(scale_factor, scale_factor, scale_factor));
+//
+//        lines_prog->set_uniform("mScale", scale_mat);
+
+        float lwidth = 2.f;
+        {
+            //auto _1 = opengl::scopeGLEnable(GL_LINE_SMOOTH);
+            //auto _2 = opengl::scopeGLLineWidth(lwidth);
+            CHECK_GL(glDrawArrays(GL_LINES, 0, vertex_count));
+        }
+
+        vbo->disable_attribute(0);
+        vbo->disable_attribute(1);
+        vbo->unbind();
+    }
+
+    void setHovered(bool hovered) override {
+
+    }
+};
+
+} // namespace
+
+std::unique_ptr<IGraphicInteractDraw> makeGraphicInteractAxis(Scene *scene, vec3f center) {
+    return std::make_unique<GraphicInteractAxis>(scene, center);
+}
+
+} // namespace zenovis

--- a/zenovis/src/bate/InteractGraphicRing.cpp
+++ b/zenovis/src/bate/InteractGraphicRing.cpp
@@ -1,0 +1,119 @@
+#include <zeno/utils/vec.h>
+#include <zenovis/Camera.h>
+#include <zenovis/Scene.h>
+#include <zenovis/bate/IGraphic.h>
+#include <zenovis/ShaderManager.h>
+#include <zenovis/opengl/buffer.h>
+#include <zenovis/opengl/shader.h>
+#include <zenovis/opengl/scope.h>
+
+namespace zenovis {
+namespace {
+
+using opengl::Buffer;
+using opengl::Program;
+using zeno::vec3f;
+
+static const char *vert_code = R"(
+    #version 120
+
+    uniform mat4 mVP;
+    uniform mat4 mInvVP;
+    uniform mat4 mView;
+    uniform mat4 mProj;
+    uniform mat4 mInvView;
+    uniform mat4 mInvProj;
+    uniform float mCameraRadius;
+
+    attribute vec3 vPosition;
+
+    void main() {
+        vec3 pos = vPosition;
+        gl_Position = vec4(pos, 1.0);
+    }
+)";
+
+static const char *frag_code = R"(
+    #version 120
+
+    uniform float alpha;
+
+    void main() {
+        gl_FragColor = vec4(100, 100, 100, alpha);
+    }
+)";
+
+struct GraphicRing final : IGraphicInteractDraw {
+    Scene *scene;
+
+    std::unique_ptr<Buffer> vbo;
+    size_t vertex_count;
+
+    vec3f center;
+    bool hover;
+
+    Program *prog;
+
+    explicit GraphicRing(Scene *scene_, vec3f center_)
+        : scene(scene_), center(center_), hover(false) {
+        vbo = std::make_unique<Buffer>(GL_ARRAY_BUFFER);
+    }
+
+    virtual void draw() override {
+        std::vector<zeno::vec3f> mem;
+
+        float r1 = 0.1, r2 = 0.08;
+        float pi = 3.1415926;
+
+        float ar = scene->camera->getAspect();
+
+        auto vp = scene->camera->m_proj * scene->camera->m_view;
+        auto screen_center = vp * glm::vec4(center[0], center[1], center[2], 1.0);
+
+        float x = screen_center[0] / screen_center[3], y = screen_center[1] / screen_center[3];
+
+        for (float theta = 0; theta <= 1.0; theta += 0.01) {
+            float sin_theta = sin(theta * 2 * pi);
+            float cos_theta = cos(theta * 2 * pi);
+            zeno::vec3f p1(x + r1 * cos_theta / ar, y + r1 * sin_theta, 0);
+            zeno::vec3f p2(x + r2 * cos_theta / ar, y + r2 * sin_theta, 0);
+            mem.emplace_back(p1);
+            mem.emplace_back(p2);
+        }
+
+        vertex_count = mem.size();
+
+        vbo->bind_data(mem.data(), mem.size() * sizeof(mem[0]));
+
+        prog = scene->shaderMan->compile_program(vert_code, frag_code);
+
+        vbo->bind();
+        vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 3, GL_FLOAT, 3);
+
+        prog->use();
+
+        scene->camera->set_program_uniforms(prog);
+
+        if (hover)
+            prog->set_uniform("alpha", 1.0);
+        else
+            prog->set_uniform("alpha", 0.5);
+
+        CHECK_GL(glDrawArrays(GL_TRIANGLE_STRIP, 0, vertex_count));
+
+        vbo->disable_attribute(0);
+        vbo->unbind();
+    }
+
+    void setHovered(bool hovered) override {
+        hover = hovered;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<IGraphicInteractDraw> makeGraphicRing(Scene *scene, vec3f center) {
+    return std::make_unique<GraphicRing>(scene, center);
+}
+
+} // namespace zenovis

--- a/zenovis/src/bate/InteractingGraphicAxis.cpp
+++ b/zenovis/src/bate/InteractingGraphicAxis.cpp
@@ -1,0 +1,168 @@
+#include <zeno/utils/vec.h>
+#include <zenovis/Camera.h>
+#include <zenovis/Scene.h>
+#include <zenovis/bate/IGraphic.h>
+#include <zenovis/ShaderManager.h>
+#include <zenovis/opengl/buffer.h>
+#include <zenovis/opengl/shader.h>
+#include <zenovis/opengl/scope.h>
+#include <glm/glm.hpp>
+
+namespace zenovis {
+namespace {
+
+using opengl::Buffer;
+using opengl::Program;
+using zeno::vec3f;
+using zeno::vec3i;
+
+static const char *vert_code = R"(
+    #version 120
+
+    uniform mat4 mVP;
+    uniform mat4 mInvVP;
+    uniform mat4 mView;
+    uniform mat4 mProj;
+    uniform mat4 mInvView;
+    uniform mat4 mInvProj;
+
+    uniform mat4 mScale;
+
+    attribute vec3 vPosition;
+    attribute vec3 vColor;
+
+    varying vec3 position;
+    varying vec3 color;
+
+    void main() {
+        position = vPosition;
+        color = vColor;
+
+        gl_Position = mVP * vec4(position, 1.0);
+    }
+)";
+
+static const char *frag_code = R"(
+    #version 120
+
+    uniform mat4 mVP;
+    uniform mat4 mInvVP;
+    uniform mat4 mView;
+    uniform mat4 mProj;
+    uniform mat4 mInvView;
+    uniform mat4 mInvProj;
+
+    varying vec3 position;
+    varying vec3 color;
+
+    void main() {
+        gl_FragColor = vec4(color, 1.0);
+    }
+)";
+
+struct GraphicInteractingAxis final : IGraphicDraw {
+    Scene *scene;
+
+    std::unique_ptr<Buffer> vbo;
+    size_t vertex_count;
+
+    vec3f center;
+    vec3i axis;
+
+    Program *lines_prog;
+    std::unique_ptr<Buffer> lines_ebo;
+    size_t lines_count;
+
+    explicit GraphicInteractingAxis(Scene *scene_, vec3f &center_,  vec3i &axis_)
+        : scene(scene_), center(center_),  axis(axis_) {
+        vbo = std::make_unique<Buffer>(GL_ARRAY_BUFFER);
+    }
+
+    virtual void draw() override {
+        std::vector<zeno::vec3f> mem;
+
+        float cx = scene->camera->m_zxx.cx;
+        float cy = scene->camera->m_zxx.cy;
+        float cz = scene->camera->m_zxx.cz;
+        float theta = scene->camera->m_zxx.theta;
+        float phi = scene->camera->m_zxx.phi;
+        float radius = scene->camera->m_zxx.radius;
+
+        auto camera_center = glm::vec3(cx, cy, cz);
+        float cos_t = glm::cos(theta), sin_t = glm::sin(theta);
+        float cos_p = glm::cos(phi), sin_p = glm::sin(phi);
+        glm::vec3 front(cos_t * sin_p, sin_t, -cos_t * cos_p);
+
+        auto camera_pos = camera_center - front * radius;
+
+        auto dist = glm::distance(camera_pos, glm::vec3(center[0], center[1], center[2]));
+
+        float bound = dist * 10;
+
+        vec3f r = vec3f(0.8, 0.2, 0.2);
+        vec3f g = vec3f(0.2, 0.6, 0.2);
+        vec3f b = vec3f(0.2, 0.2, 0.8);
+
+        auto [x, y, z] = center;
+
+        if (axis[0]) {
+            mem.emplace_back(x - bound, y, z);
+            mem.push_back(r);
+            mem.emplace_back(x + bound, y, z);
+            mem.push_back(r);
+        }
+
+        if (axis[1]) {
+            mem.emplace_back(x, y - bound, z);
+            mem.push_back(g);
+            mem.emplace_back(x, y + bound, z);
+            mem.push_back(g);
+        }
+
+        if (axis[2]) {
+            mem.emplace_back(x, y, z - bound);
+            mem.push_back(b);
+            mem.emplace_back(x, y, z + bound);
+            mem.push_back(b);
+        }
+
+        vertex_count = mem.size() / 2;
+        lines_count = vertex_count / 2;
+
+        vbo->bind_data(mem.data(), mem.size() * sizeof(mem[0]));
+
+        lines_prog = scene->shaderMan->compile_program(vert_code, frag_code);
+
+        vbo->bind();
+        vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 6, GL_FLOAT, 3);
+        vbo->attribute(1, sizeof(float) * 3, sizeof(float) * 6, GL_FLOAT, 3);
+
+        lines_prog->use();
+        scene->camera->set_program_uniforms(lines_prog);
+
+        //        float scale_factor = 1 / scene->camera->m_zxx.radius;
+        //        glm::mat4 scale_mat = glm::mat4(1.0f);
+        //        scale_mat = glm::scale(scale_mat, glm::vec3(scale_factor, scale_factor, scale_factor));
+        //
+        //        lines_prog->set_uniform("mScale", scale_mat);
+
+        float lwidth = 2.f;
+        {
+            //auto _1 = opengl::scopeGLEnable(GL_LINE_SMOOTH);
+            //auto _2 = opengl::scopeGLLineWidth(lwidth);
+            CHECK_GL(glDrawArrays(GL_LINES, 0, vertex_count));
+        }
+
+        vbo->disable_attribute(0);
+        vbo->disable_attribute(1);
+        vbo->unbind();
+    }
+};
+
+} // namespace
+
+std::unique_ptr<IGraphicDraw> makeGraphicInteractingAxis(Scene *scene, vec3f center, vec3i axis) {
+    return std::make_unique<GraphicInteractingAxis>(scene, center, axis);
+}
+
+} // namespace zenovis

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -35,6 +35,7 @@ struct RenderEngineBate : RenderEngine {
     }
 
     void update() override {
+        if (scene->drawOptions->interactive) graphicsMan->graphics.clear();
         graphicsMan->load_objects(scene->objectsMan->pairsShared());
     }
 
@@ -51,6 +52,21 @@ struct RenderEngineBate : RenderEngine {
         if (scene->drawOptions->show_grid) {
             for (auto const &hudgra : hudGraphics) {
                 hudgra->draw();
+            }
+        }
+        if (!scene->selected.empty() && !scene->drawOptions->interactive) {
+            CHECK_GL(glClear(GL_DEPTH_BUFFER_BIT));
+            for (auto const &[intgraid, intgra] : scene->drawOptions->interactGraphics) {
+                intgra->setHovered(false);
+                if (intgraid == scene->drawOptions->hovered_graphic_id)
+                    intgra->setHovered(true);
+                intgra->draw();
+            }
+        }
+        if (!scene->selected.empty() && scene->drawOptions->interactive) {
+            CHECK_GL(glClear(GL_DEPTH_BUFFER_BIT));
+            for (auto const &intgra : scene->drawOptions->interactingGraphics) {
+                intgra->draw();
             }
         }
     }


### PR DESCRIPTION
This pr makes view port interactive. Now you can transform objects in view port directly!
1. Control transformation with keyboard shortcuts, I will implement handles for better user experience in next pr.
2. After transforming in view port, a new transform primitive node will be generated near the object node. But if the object is the prim output of a exist transform primitive node and there is no input nodes linked to translation/rotation/scaling socket, the data of this node will be changed.
3. Only support translation/rotation/scaling in the world coordinate in this version. 
