### PR TITLE
fixed openFileDialog waring on windows

### DIFF
--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -694,11 +694,10 @@ void ZenoMainWindow::saveAs() {
 
 QString ZenoMainWindow::getOpenFileByDialog() {
     DlgInEventLoopScope;
-    const QString &initialPath = ".";
+    const QString &initialPath = "";
     QFileDialog fileDialog(this, tr("Open"), initialPath, "Zeno Graph File (*.zsg)\nAll Files (*)");
     fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
     fileDialog.setFileMode(QFileDialog::ExistingFile);
-    fileDialog.setDirectory(initialPath);
     if (fileDialog.exec() != QDialog::Accepted)
         return "";
 


### PR DESCRIPTION
<!-- Thank for you contribution!
  -- If this is your first contribution to Zeno, make sure you've checked out the contributor guidelines:
  --
  -- https://github.com/zenustech/zeno/blob/master/docs/CONTRIBUTING.md
  -->

Related issue number (if any) = #...

on windows11, when clicking open file there will be a waring:```QWindowsNativeFileDialogBase::shellitemFromParsingName(file:.) failed```
![image](https://user-images.githubusercontent.com/40262194/190302790-045d8961-087e-4374-9e13-60e330e3fa6e.png)

and set QFileDialog directory as empty string, open file will open last opened path, [reference](https://stackoverflow.com/questions/23002801/how-to-make-getopenfilename-remember-last-opening-path)