### PR TITLE
double click object will focus on corresponding node

### DIFF
--- a/ui/zenoedit/nodesview/zenographseditor.h
+++ b/ui/zenoedit/nodesview/zenographseditor.h
@@ -28,6 +28,7 @@ class ZenoGraphsEditor : public QWidget
 public:
     ZenoGraphsEditor(ZenoMainWindow* pMainWin);
     ~ZenoGraphsEditor();
+    void activateTab(const QString& subGraphName, const QString& path = "", const QString& objId = "", bool isError = false);
 
 public slots:
 	void resetModel(IGraphsModel* pModel);
@@ -56,7 +57,6 @@ private:
     void initRecentFiles();
     void initModel();
     int tabIndexOfName(const QString& subGraphName);
-    void activateTab(const QString& subGraphName, const QString& path = "", const QString& objId = "", bool isError = false);
 
     ZenoMainWindow* m_mainWin;
     Ui::GraphsEditor* m_ui;

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -13,6 +13,7 @@
 #include <zeno/funcs/ObjectGeometryInfo.h>
 #include <util/log.h>
 #include <zenoui/style/zenostyle.h>
+#include <nodesview/zenographseditor.h>
 //#include <zeno/utils/zeno_p.h>
 // #include <nodesys/nodesmgr.h>
 #include <zenomodel/include/nodesmgr.h>
@@ -324,6 +325,42 @@ void CameraControl::fakeWheelEvent(QWheelEvent* event)
         zenoApp->getMainWindow()->lightPanel->camApertureEdit->setText(QString::number(m_aperture));
         zenoApp->getMainWindow()->lightPanel->camDisPlaneEdit->setText(QString::number(m_focalPlaneDistance));
     }
+}
+
+void CameraControl::fakeMouseDoubleClickEvent(QMouseEvent* event) {
+    auto scene = Zenovis::GetInstance().getSession()->get_scene();
+    auto cam_pos = realPos();
+
+    float x = (float)event->x() / m_res.x();
+    float y = (float)event->y() / m_res.y();
+    auto rdir = screenToWorldRay(x, y);
+    float min_t = std::numeric_limits<float>::max();
+    std::string name;
+    for (auto const &[key, ptr] : scene->objectsMan->pairs()) {
+        zeno::vec3f ro(cam_pos[0], cam_pos[1], cam_pos[2]);
+        zeno::vec3f rd(rdir[0], rdir[1], rdir[2]);
+        zeno::vec3f bmin, bmax;
+        if (zeno::objectGetBoundingBox(ptr, bmin, bmax) ){
+            if (auto ret = ray_box_intersect(bmin, bmax, ro, rd)) {
+                float t = *ret;
+                if (t < min_t) {
+                    min_t = t;
+                    name = key;
+                }
+            }
+        }
+    }
+    if (!name.empty()) {
+        IGraphsModel* pModel = zenoApp->graphsManagment()->currentModel();
+        auto node_id = QString(name.substr(0, name.find_first_of(':')).c_str());
+        auto graph_editor = zenoApp->getMainWindow()->editor();
+        auto search_result = pModel->search(node_id, SEARCH_NODEID);
+        auto subgraph_index = search_result[0].subgIdx;
+        auto subgraph_name = subgraph_index.data(ROLE_OBJNAME).toString();
+        graph_editor->activateTab(subgraph_name, "", node_id);
+    }
+    else
+        scene->selected.clear();
 }
 
 void CameraControl::setKeyFrame()
@@ -640,6 +677,12 @@ void ViewportWidget::wheelEvent(QWheelEvent* event)
 void ViewportWidget::mouseReleaseEvent(QMouseEvent *event) {    
     _base::mouseReleaseEvent(event);
     m_camera->fakeMouseReleaseEvent(event); 
+    update();
+}
+
+void ViewportWidget::mouseDoubleClickEvent(QMouseEvent* event) {
+    _base::mouseReleaseEvent(event);
+    m_camera->fakeMouseDoubleClickEvent(event);
     update();
 }
 

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -352,11 +352,13 @@ void CameraControl::fakeMouseDoubleClickEvent(QMouseEvent* event) {
     }
     if (!name.empty()) {
         IGraphsModel* pModel = zenoApp->graphsManagment()->currentModel();
-        auto node_id = QString(name.substr(0, name.find_first_of(':')).c_str());
+        auto obj_name = QString(name.c_str());
+        QString subgraph_name, node_id;
         auto graph_editor = zenoApp->getMainWindow()->editor();
+        node_id = QString(name.substr(0, name.find_first_of(':')).c_str());
         auto search_result = pModel->search(node_id, SEARCH_NODEID);
         auto subgraph_index = search_result[0].subgIdx;
-        auto subgraph_name = subgraph_index.data(ROLE_OBJNAME).toString();
+        subgraph_name = subgraph_index.data(ROLE_OBJNAME).toString();
         graph_editor->activateTab(subgraph_name, "", node_id);
     }
     else

--- a/ui/zenoedit/viewport/viewportwidget.h
+++ b/ui/zenoedit/viewport/viewportwidget.h
@@ -56,6 +56,7 @@ public:
     void fakeMouseReleaseEvent(QMouseEvent* event);
     void fakeMouseMoveEvent(QMouseEvent* event);
     void fakeWheelEvent(QWheelEvent* event);
+    void fakeMouseDoubleClickEvent(QMouseEvent* event);
     void focus(QVector3D center, float radius);
     QVector3D realPos() const;
     QVector3D screenToWorldRay(float x, float y) const;
@@ -110,6 +111,7 @@ protected:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -294,7 +294,9 @@ void ZenoMainWindow::initDocks() {
     m_editor = new ZenoDockWidget("", this);
     m_editor->setObjectName(uniqueDockObjName(DOCK_EDITOR));
     m_editor->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetFloatable);
-    m_editor->setWidget(DOCK_EDITOR, new ZenoGraphsEditor(this));
+    m_pEditor = new ZenoGraphsEditor(this);
+    m_editor->setWidget(DOCK_EDITOR, m_pEditor);
+    // m_editor->setWidget(DOCK_EDITOR, new ZenoGraphsEditor(this));
 
     m_logger = new ZenoDockWidget("logger", this);
     m_logger->setObjectName(uniqueDockObjName(DOCK_LOG));


### PR DESCRIPTION
Not support subgraph node yet.
If double clicked a object generated from a subgraph, zeno will focus on subgraph node instead of the real corresponding node.
