### PR TITLE
zencache io optimization

### DIFF
--- a/ui/zenoedit/launch/corelaunch.h
+++ b/ui/zenoedit/launch/corelaunch.h
@@ -6,6 +6,7 @@
 class IGraphsModel;
 
 void launchProgram(IGraphsModel* pModel, int beginFrame, int endFrame);
+bool initZenCache();
 void killProgram();
 
 #endif

--- a/ui/zenoedit/launch/runnermain.cpp
+++ b/ui/zenoedit/launch/runnermain.cpp
@@ -102,16 +102,7 @@ static int runner_start(std::string const &progJson, int sessionid) {
     if (session->globalStatus->failed())
         return onfail();
 
-    QSettings settings(zsCompanyName, zsEditor);
-    const QString& cachedir = settings.value("zencachedir").toString();
-    const QString& cachenum = settings.value("zencachenum").toString();
-    bool bDiskCache = false;
-    int cnum = cachenum.toInt(&bDiskCache);
-    bDiskCache = bDiskCache && QFileInfo(cachedir).isDir() && cnum > 0;
-    if (bDiskCache) {
-        auto cdir = cachedir.toStdString();
-        session->globalComm->frameCache(cdir.c_str(), cnum);
-    }
+    bool bZenCache = initZenCache();
 
     std::vector<char> buffer;
 
@@ -145,7 +136,7 @@ static int runner_start(std::string const &progJson, int sessionid) {
 
         send_packet("{\"action\":\"newFrame\"}", "", 0);
 
-        if (bDiskCache) {
+        if (bZenCache) {
             session->globalComm->dumpFrameCache(frame);
         } else {
             auto const& viewObjs = session->globalComm->getViewObjects();

--- a/ui/zenoedit/launch/runnermain.cpp
+++ b/ui/zenoedit/launch/runnermain.cpp
@@ -107,7 +107,7 @@ static int runner_start(std::string const &progJson, int sessionid) {
     const QString& cachenum = settings.value("zencachenum").toString();
     bool bDiskCache = false;
     int cnum = cachenum.toInt(&bDiskCache);
-    bDiskCache = bDiskCache & QFileInfo(cachedir).isDir();
+    bDiskCache = bDiskCache && QFileInfo(cachedir).isDir() && cnum > 0;
     if (bDiskCache) {
         auto cdir = cachedir.toStdString();
         session->globalComm->frameCache(cdir.c_str(), cnum);

--- a/ui/zenoedit/timeline/ztimeline.cpp
+++ b/ui/zenoedit/timeline/ztimeline.cpp
@@ -154,9 +154,13 @@ bool ZTimeline::isAlways() const
     return m_ui->btnAlways->isChecked();
 }
 
-void ZTimeline::setFromTo(int frameFrom, int frameTo)
+void ZTimeline::initFromTo(int frameFrom, int frameTo)
 {
-    m_ui->editFrame->setText(QString::number(frameFrom));
+    BlockSignalScope s1(m_ui->timeliner);
+    BlockSignalScope s2(m_ui->editFrom);
+    BlockSignalScope s3(m_ui->editTo);
+
+    m_ui->editFrom->setText(QString::number(frameFrom));
     m_ui->editTo->setText(QString::number(frameTo));
     if (frameTo >= frameFrom)
         m_ui->timeliner->setFromTo(frameFrom, frameTo);

--- a/ui/zenoedit/timeline/ztimeline.h
+++ b/ui/zenoedit/timeline/ztimeline.h
@@ -17,7 +17,7 @@ class ZTimeline : public QWidget
 public:
     ZTimeline(QWidget* parent = nullptr);
     QPair<int, int> fromTo() const;
-    void setFromTo(int from, int to);
+    void initFromTo(int from, int to);
     bool isAlways() const;
     void setAlways(bool bOn);
     void resetSlider();

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -803,10 +803,12 @@ TIMELINE_INFO DisplayWidget::timelineInfo()
     return info;
 }
 
-void DisplayWidget::setTimelineInfo(TIMELINE_INFO info)
+void DisplayWidget::resetTimeline(TIMELINE_INFO info)
 {
+    BlockSignalScope scope(m_timeline);
     m_timeline->setAlways(info.bAlways);
-    m_timeline->setFromTo(info.beginFrame, info.endFrame);
+    m_timeline->initFromTo(info.beginFrame, info.endFrame);
+    m_timeline->setSliderValue(info.currFrame);
 }
 
 ViewportWidget* DisplayWidget::getViewportWidget()

--- a/ui/zenoedit/viewport/viewportwidget.h
+++ b/ui/zenoedit/viewport/viewportwidget.h
@@ -135,7 +135,7 @@ public:
     void init();
     QSize sizeHint() const override;
     TIMELINE_INFO timelineInfo();
-    void setTimelineInfo(TIMELINE_INFO info);
+    void resetTimeline(TIMELINE_INFO info);
     ViewportWidget* getViewportWidget();
 
 public slots:

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -465,7 +465,7 @@ bool ZenoMainWindow::openFile(QString filePath)
     if (!pModel)
         return false;
 
-    setTimelineInfo(pGraphs->timeInfo());
+    resetTimeline(pGraphs->timeInfo());
     recordRecentFile(filePath);
     return true;
 }
@@ -594,7 +594,7 @@ void ZenoMainWindow::saveQuit() {
     }
     pGraphsMgm->clear();
     //clear timeline info.
-    setTimelineInfo(TIMELINE_INFO());
+    resetTimeline(TIMELINE_INFO());
 }
 
 void ZenoMainWindow::save()
@@ -639,12 +639,12 @@ TIMELINE_INFO ZenoMainWindow::timelineInfo()
     return info;
 }
 
-void ZenoMainWindow::setTimelineInfo(TIMELINE_INFO info)
+void ZenoMainWindow::resetTimeline(TIMELINE_INFO info)
 {
     DisplayWidget* view = qobject_cast<DisplayWidget*>(m_viewDock->widget());
     if (view)
     {
-        view->setTimelineInfo(info);
+        view->resetTimeline(info);
     }
 }
 

--- a/ui/zenoedit/zenomainwindow.h
+++ b/ui/zenoedit/zenomainwindow.h
@@ -21,7 +21,7 @@ public:
     bool inDlgEventLoop() const;
     void setInDlgEventLoop(bool bOn);
     TIMELINE_INFO timelineInfo();
-    void setTimelineInfo(TIMELINE_INFO info);
+    void resetTimeline(TIMELINE_INFO info);
 
     ZenoLights* lightPanel = nullptr;
 

--- a/ui/zenomodel/src/modelacceptor.cpp
+++ b/ui/zenomodel/src/modelacceptor.cpp
@@ -44,7 +44,10 @@ bool ModelAcceptor::setLegacyDescs(const rapidjson::Value& graphObj, const NODE_
 
 void ModelAcceptor::setTimeInfo(const TIMELINE_INFO& info)
 {
-    m_timeInfo = info;
+    m_timeInfo.beginFrame = qMin(info.beginFrame, info.endFrame);
+    m_timeInfo.endFrame = qMax(info.beginFrame, info.endFrame);
+    m_timeInfo.currFrame = qMax(qMin(m_timeInfo.currFrame, m_timeInfo.endFrame),
+        m_timeInfo.beginFrame);
 }
 
 TIMELINE_INFO ModelAcceptor::timeInfo() const

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -32,6 +32,7 @@ struct GlobalComm {
     ZENO_API void frameRange(int beg, int end);
     ZENO_API void newFrame();
     ZENO_API void finishFrame();
+    ZENO_API void dumpFrameCache(int frameid);
     ZENO_API void addViewObject(std::string const &key, std::shared_ptr<IObject> object);
     ZENO_API int maxPlayFrames();
     ZENO_API void clearState();

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -36,7 +36,7 @@ struct GlobalComm {
     ZENO_API void addViewObject(std::string const &key, std::shared_ptr<IObject> object);
     ZENO_API int maxPlayFrames();
     ZENO_API void clearState();
-    ZENO_API ViewObjects const *getViewObjects(int frameid);
+    ZENO_API ViewObjects const *getViewObjects(const int frameid);
     ZENO_API ViewObjects const &getViewObjects();
     ZENO_API bool isFrameCompleted(int frameid) const;
 };

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -89,14 +89,16 @@ ZENO_API void GlobalComm::finishFrame() {
     log_debug("GlobalComm::finishFrame {}", m_maxPlayFrame);
     if (m_maxPlayFrame >= 0 && m_maxPlayFrame < m_frames.size())
         m_frames[m_maxPlayFrame].b_frame_completed = true;
-
-    if (maxCachedFrames != 0) { // immediatedump
-        int i = m_maxPlayFrame;
-        toDisk(cacheFramePath, i, m_frames[i].view_objects);
-        m_inCacheFrames.erase(i);
-    }
-
     m_maxPlayFrame += 1;
+}
+
+ZENO_API void GlobalComm::dumpFrameCache(int frameid) {
+    std::lock_guard lck(m_mtx);
+    int offset = frameid - beginFrameNumber;
+    if (offset >= 0 && frameid < m_frames.size()) {
+        log_debug("dumping frame {}", frameid);
+        toDisk(cacheFramePath, frameid, m_frames[offset].view_objects);
+    }
 }
 
 ZENO_API void GlobalComm::addViewObject(std::string const &key, std::shared_ptr<IObject> object) {


### PR DESCRIPTION
1. dump objs in core proc after apply nodes, rather than on ui process.
2. replace istreambuf_iterator with fread when import cache from disk.
3. fix some timeline bug.