### PR TITLE
CameraNode fix

### DIFF
--- a/projects/FBX/EvalFBXAnim.cpp
+++ b/projects/FBX/EvalFBXAnim.cpp
@@ -252,10 +252,11 @@ struct EvalAnim{
             bool infd = false;
             int bCount = 0;
             for(auto& b: bwe){
-                float bIndex = (float)m_JointCorrespondingIndex[b.first];
-                prim->verts.attr<float>("jointIndice_" + std::to_string(bCount)).push_back(bIndex);
-                prim->verts.attr<float>("jointWeight_" + std::to_string(bCount)).push_back(b.second);
-
+                if(jie){
+                    float bIndex = (float)m_JointCorrespondingIndex[b.first];
+                    prim->verts.attr<float>("jointIndice_" + std::to_string(bCount)).push_back(bIndex);
+                    prim->verts.attr<float>("jointWeight_" + std::to_string(bCount)).push_back(b.second);
+                }
                 //std::cout << "FBX: Vert " << i << " name " << b.first << " bIndex " << bIndex << std::endl;
                 infd = true;
                 auto& tr = m_Transforms[b.first];

--- a/projects/FBX/MayaCamera.cpp
+++ b/projects/FBX/MayaCamera.cpp
@@ -126,10 +126,10 @@ struct CameraNode: zeno::INode{
         camera->pos = get_input2<zeno::vec3f>("pos");
         camera->up = get_input2<zeno::vec3f>("up");
         camera->view = get_input2<zeno::vec3f>("view");
-        camera->fnear = get_input2<float>("frame");
         camera->fov = get_input2<float>("fov");
         camera->aperture = get_input2<float>("aperture");
         camera->focalPlaneDistance = get_input2<float>("focalPlaneDistance");
+        camera->userData().set2("frame", get_input2<float>("frame"));
 
         set_output("camera", std::move(camera));
     }
@@ -180,15 +180,15 @@ struct CameraEval: zeno::INode {
 
         //zeno::log_info("CameraEval frame {}", frameid);
 
-        // TODO sort CameraObject by fnear(frameId)
+        // TODO sort CameraObject by (frameId)
 
         if(nodelist.size() == 1){
             auto n = nodelist[0];
             SET_CAMERA_DATA
             //zeno::log_info("CameraEval size 1");
         }else{
-            int ff = (int)nodelist[0]->fnear;
-            int lf = (int)nodelist[nodelist.size()-1]->fnear;
+            int ff = (int)nodelist[0]->userData().get2<float>("frame");
+            int lf = (int)nodelist[nodelist.size()-1]->userData().get2<float>("frame");
             if(frameid <= ff){
                 auto n = nodelist[0];
                 SET_CAMERA_DATA
@@ -201,7 +201,7 @@ struct CameraEval: zeno::INode {
                 for(int i=1;i<nodelist.size();i++){
                     auto const & n = nodelist[i];
                     auto const & nm = nodelist[i-1];
-                    int cf = (int)n->fnear;
+                    int cf = (int)n->userData().get2<float>("frame");
                     if(frameid < cf){
                         zeno::vec3f pos;
                         zeno::vec3f up;
@@ -210,9 +210,9 @@ struct CameraEval: zeno::INode {
                         float aperture;
                         float focalPlaneDistance;
 
-                        float factor = (float)(frameid - (int)nm->fnear) / (float)((int)n->fnear - (int)nm->fnear);
-
-                        //zeno::log_info("CameraEval Interval {} {} factor {}", (int)nm->fnear, (int)n->fnear, factor);
+                        float factor = (float)(frameid - (int)nm->userData().get2<float>("frame"))
+                                       / (float)((int)n->userData().get2<float>("frame")
+                                           - (int)nm->userData().get2<float>("frame"));
 
                         // linear interpolation
                         if(inter_mode == "Linear"){


### PR DESCRIPTION
1. 修改了FBX中的CameraNode的fnear参数，使在光追与GL模式下工作正常
2. 修复了EvalFBXAnim中对没有动画的FBX的处理