### PR TITLE
[fix] property-panel display size problem.

### DIFF
--- a/ui/zenoedit/panel/zenoproppanel.cpp
+++ b/ui/zenoedit/panel/zenoproppanel.cpp
@@ -12,6 +12,7 @@
 #include <zenoui/comctrl/zexpandablesection.h>
 #include <zenoui/comctrl/zlinewidget.h>
 #include <zenoui/comctrl/zlineedit.h>
+#include <zenoui/comctrl/ztextedit.h>
 #include "util/log.h"
 #include "util/apphelper.h"
 
@@ -89,10 +90,12 @@ void ZenoPropPanel::reset(IGraphsModel* pModel, const QModelIndex& subgIdx, cons
 	pTitleLayout->setContentsMargins(15, 15, 15, 15);
 	QLabel* pLabel = new QLabel(m_idx.data(ROLE_OBJNAME).toString());
 	pLabel->setProperty("cssClass", "proppanel-nodename");
+	pLabel->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	pTitleLayout->addWidget(pLabel);
 	pTitleLayout->addStretch();
 	QLabel* pWiki = new QLabel(tr("Wiki"));
 	pWiki->setProperty("cssClass", "proppanel");
+	pWiki->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	pTitleLayout->addWidget(pWiki);
 
 	pMainLayout->addLayout(pTitleLayout);
@@ -111,7 +114,6 @@ void ZenoPropPanel::reset(IGraphsModel* pModel, const QModelIndex& subgIdx, cons
 		pMainLayout->addWidget(box);
 	}
 
-	pMainLayout->addStretch();
 	pMainLayout->setSpacing(0);
 
 	update();
@@ -188,6 +190,7 @@ ZExpandableSection* ZenoPropPanel::paramsBox(IGraphsModel* pModel, const QModelI
 				pComboBox->setObjectName(paramName);
 				pComboBox->setProperty("control", param.control);
 				pComboBox->setCurrentText(param.value.toString());
+				pComboBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
 				//todo: unify
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
@@ -238,21 +241,20 @@ ZExpandableSection* ZenoPropPanel::paramsBox(IGraphsModel* pModel, const QModelI
                 ZVecEditor* pVecEdit = new ZVecEditor(vec, bFloat, 3, "proppanel");
                 pVecEdit->setObjectName(paramName);
 				pVecEdit->setProperty("control", param.control);
-                connect(pVecEdit, &ZVecEditor::valueChanged, this, &ZenoPropPanel::onInputEditFinish);
+                connect(pVecEdit, &ZVecEditor::valueChanged, this, &ZenoPropPanel::onParamEditFinish);
 
                 pLayout->addWidget(pVecEdit, r++, 1);
                 break;
             }
 			case CONTROL_MULTILINE_STRING:
 			{
-				QTextEdit* pTextEdit = new QTextEdit;
+				ZTextEdit* pTextEdit = new ZTextEdit;
 				pTextEdit->setFrameShape(QFrame::NoFrame);
 				pTextEdit->setProperty("cssClass", "proppanel");
 				pTextEdit->setObjectName(paramName);
 				pTextEdit->setProperty("control", param.control);
 				pTextEdit->setFont(QFont("HarmonyOS Sans", 12));
-
-				//todo: ztextedit impl.
+				pTextEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
 
 				QTextCharFormat format;
 				QFont font("HarmonyOS Sans", 12);
@@ -263,6 +265,8 @@ ZExpandableSection* ZenoPropPanel::paramsBox(IGraphsModel* pModel, const QModelI
 				QPalette pal = pTextEdit->palette();
 				pal.setColor(QPalette::Base, QColor(37, 37, 37));
 				pTextEdit->setPalette(pal);
+
+				QObject::connect(pTextEdit, &ZTextEdit::editFinished, this, &ZenoPropPanel::onParamEditFinish);
 
 				pLayout->addWidget(pTextEdit, r++, 1);
 				break;
@@ -290,6 +294,7 @@ ZExpandableSection* ZenoPropPanel::paramsBox(IGraphsModel* pModel, const QModelI
 		}
 	}
 
+	pLayout->setRowStretch(pLayout->rowCount(), 1);
 	pParamsBox->setContentLayout(pLayout);
 	return pParamsBox;
 }
@@ -406,6 +411,8 @@ ZExpandableSection* ZenoPropPanel::inputsBox(IGraphsModel* pModel, const QModelI
 		delete pLayout;
 		return nullptr;
 	}
+
+	pLayout->setRowStretch(pLayout->rowCount(), 1);
 
 	ZExpandableSection* pInputsBox = new ZExpandableSection("SOCKET IN");
 	pInputsBox->setContentLayout(pLayout);

--- a/ui/zenoui/comctrl/zexpandablesection.h
+++ b/ui/zenoui/comctrl/zexpandablesection.h
@@ -14,6 +14,16 @@ public:
     virtual QSize minimumSizeHint() const override;
 };
 
+class ZScrollArea : public QScrollArea
+{
+	Q_OBJECT
+public:
+	ZScrollArea(QWidget* parent = nullptr);
+	virtual QSize sizeHint() const override;
+
+private:
+	mutable QSize widgetSize;
+};
 
 class ZExpandableSection : public QWidget
 {
@@ -24,13 +34,17 @@ public:
 	virtual QSize sizeHint() const override;
     virtual QSize minimumSizeHint() const override;
 
+protected:
+	void mousePressEvent(QMouseEvent* event) override;
+
 public slots:
 	void toggle(bool collasped);
 
 private:
+	QString m_title;
 	QGridLayout* m_mainLayout;
 	ZIconLabel* m_collaspBtn;
-	QScrollArea* m_contentArea;
+	ZScrollArea* m_contentArea;
 	QWidget* m_contentWidget;
 };
 

--- a/ui/zenoui/comctrl/ztextedit.cpp
+++ b/ui/zenoui/comctrl/ztextedit.cpp
@@ -1,0 +1,42 @@
+#include "ztextedit.h"
+
+
+ZTextEdit::ZTextEdit(QWidget* parent)
+    : QTextEdit(parent)
+{
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    //connect(this, &QTextEdit::textC)
+}
+
+ZTextEdit::ZTextEdit(const QString& text, QWidget* parent)
+    : QTextEdit(text, parent)
+{
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+}
+
+QSize ZTextEdit::sizeHint() const
+{
+    QSize s(document()->size().toSize());
+    /*
+     * Make sure width and height have `usable' values.
+     */
+    s.rwidth() = std::max(100, s.width());
+    s.rheight() = std::max(100, s.height());
+    return s;
+}
+
+void ZTextEdit::focusOutEvent(QFocusEvent* e)
+{
+    QTextEdit::focusOutEvent(e);
+    emit editFinished();
+}
+
+void ZTextEdit::resizeEvent(QResizeEvent* event)
+{
+    updateGeometry();
+    QTextEdit::resizeEvent(event);
+}

--- a/ui/zenoui/comctrl/ztextedit.h
+++ b/ui/zenoui/comctrl/ztextedit.h
@@ -1,0 +1,22 @@
+#ifndef __ZTEXTEDIT_H__
+#define __ZTEXTEDIT_H__
+
+#include <QtWidgets>
+
+class ZTextEdit : public QTextEdit
+{
+    Q_OBJECT
+public:
+    explicit ZTextEdit(QWidget* parent = nullptr);
+    explicit ZTextEdit(const QString& text, QWidget* parent = nullptr);
+    QSize sizeHint() const override;
+
+signals:
+    void editFinished();
+
+protected:
+    void focusOutEvent(QFocusEvent* e) override;
+    void resizeEvent(QResizeEvent* event) override;
+};
+
+#endif


### PR DESCRIPTION
the content of group widget on panel cannot not be expansive, so implement a subclass QScrollArea and override the sizehint function.

affect: just widget shown on property-panel.
