### PR TITLE
Zeno fixbug

### DIFF
--- a/ui/zenoedit/acceptor/transferacceptor.cpp
+++ b/ui/zenoedit/acceptor/transferacceptor.cpp
@@ -270,6 +270,29 @@ void TransferAcceptor::setParamValue(const QString& id, const QString& nodeCls, 
     }
     else
     {
+        if (nodeCls == "MakeCurvemap" && (name == "_POINTS" || name == "_HANDLERS"))
+        {
+            PARAM_INFO paramData;
+            paramData.control = CONTROL_NONVISIBLE;
+            paramData.name = name;
+            paramData.bEnableConnect = false;
+            paramData.value = var;
+            params[name] = paramData;
+            data[ROLE_PARAMETERS] = QVariant::fromValue(params);
+            return;
+        }
+        if (nodeCls == "MakeHeatmap" && name == "_RAMPS")
+        {
+            PARAM_INFO paramData;
+            paramData.control = CONTROL_COLOR;
+            paramData.name = name;
+            paramData.bEnableConnect = false;
+            paramData.value = var;
+            params[name] = paramData;
+            data[ROLE_PARAMETERS] = QVariant::fromValue(params);
+            return;
+        }
+
         PARAMS_INFO _params = data[ROLE_PARAMS_NO_DESC].value<PARAMS_INFO>();
         _params[name].value = var;
         data[ROLE_PARAMS_NO_DESC] = QVariant::fromValue(_params);

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -161,6 +161,7 @@ ZENO_API GlobalComm::ViewObjects const *GlobalComm::getViewObjects(const int fra
                         // seems that objs will not be modified when load_objects called later.
                         // so, there is no need to dump.
                         //toDisk(cacheFramePath, i, m_frames[i - beginFrameNumber].view_objects);
+                        m_frames[i - beginFrameNumber].view_objects.clear();
                         m_inCacheFrames.erase(i);
                         break;
                     }


### PR DESCRIPTION
1. forget to free cached viewobject when switch frame.
2. copy color node.
