### PR TITLE
accout for no curvature input into pressure solver

### DIFF
--- a/projects/FastFLIP/nosys/SolvePoissonPressureEqn.cpp
+++ b/projects/FastFLIP/nosys/SolvePoissonPressureEqn.cpp
@@ -35,7 +35,10 @@ struct AssembleSolvePPE : zeno::INode {
     auto velocity = get_input("Velocity")->as<VDBFloat3Grid>();
     auto solid_velocity = get_input("SolidVelocity")->as<VDBFloat3Grid>();
 
-    auto curvature = get_input("Curvature")->as<VDBFloatGrid>();
+    openvdb::FloatGrid::Ptr curvatureGrid = openvdb::FloatGrid::create();
+    if(has_input("Curvature")) {
+      curvatureGrid = get_input("Curvature")->as<VDBFloatGrid>()->m_grid;
+    }
     auto density = get_input("Density")->as<zeno::NumericObject>()->get<float>();
     auto tension_coef = get_input("SurfaceTension")->as<zeno::NumericObject>()->get<float>();
     bool enable_tension = tension_coef > 0? true : false;
@@ -51,7 +54,7 @@ struct AssembleSolvePPE : zeno::INode {
     packed_velocity.from_vec3(velocity->m_grid);
         
     FLIP_vdb::solve_pressure_simd_uaamg(
-        liquid_sdf->m_grid, curvature->m_grid, rhsgrid->m_grid,
+        liquid_sdf->m_grid, curvatureGrid, rhsgrid->m_grid,
         curr_pressure->m_grid, face_weight->m_grid,
         packed_velocity, solid_velocity->m_grid,
         density, tension_coef, enable_tension, dt, dx);

--- a/projects/FastFLIP/nosys/SubtractPressureGradient.cpp
+++ b/projects/FastFLIP/nosys/SubtractPressureGradient.cpp
@@ -38,7 +38,10 @@ struct SubtractPressureGradient : zeno::INode {
     auto velocity = get_input("Velocity")->as<VDBFloat3Grid>();
     auto solid_velocity = get_input("SolidVelocity")->as<VDBFloat3Grid>();
 
-    auto curvature = get_input("Curvature")->as<VDBFloatGrid>();
+    openvdb::FloatGrid::Ptr curvatureGrid = openvdb::FloatGrid::create();
+    if(has_input("Curvature")) {
+      curvatureGrid = get_input("Curvature")->as<VDBFloatGrid>()->m_grid;
+    }
     auto density = get_input("Density")->as<zeno::NumericObject>()->get<float>();
     auto tension_coef = get_input("SurfaceTension")->as<zeno::NumericObject>()->get<float>();
     bool enable_tension = tension_coef > 0? true : false;
@@ -50,7 +53,7 @@ struct SubtractPressureGradient : zeno::INode {
         liquid_sdf->m_grid, solid_sdf->m_grid,
         curr_pressure->m_grid, face_weight->m_grid,
         packed_velocity, solid_velocity->m_grid,
-        curvature->m_grid, density, tension_coef, enable_tension, 
+        curvatureGrid, density, tension_coef, enable_tension, 
         dt, dx);
 
     vdb_velocity_extrapolator::union_extrapolate(n,


### PR DESCRIPTION
handle the case of no input of curvature grid into the nodes "AssembleSolvePPE" and "SubtractPressureGradient"