### PR TITLE
Simple Render Dally

### DIFF
--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -480,6 +480,7 @@ ViewportWidget::ViewportWidget(QWidget* parent)
     : QGLWidget(parent)
     , m_camera(nullptr)
     , updateLightOnce(true)
+    , m_pauseRenderDally(new QTimer)
 {
     QGLFormat fmt;
     int nsamples = 16;  // TODO: adjust in a zhouhang-panel
@@ -494,6 +495,20 @@ ViewportWidget::ViewportWidget(QWidget* parent)
 
     m_camera = std::make_shared<CameraControl>();
     Zenovis::GetInstance().m_camera_control = m_camera.get();
+
+    connect(m_pauseRenderDally, &QTimer::timeout, [&](){
+        auto scene = Zenovis::GetInstance().getSession()->get_scene();
+        scene->drawOptions->simpleRender = false;
+        scene->drawOptions->needRefresh = true;
+        m_pauseRenderDally->stop();
+    });
+}
+
+void ViewportWidget::setSimpleRenderOption() {
+    auto scene = Zenovis::GetInstance().getSession()->get_scene();
+    scene->drawOptions->simpleRender = true;
+    m_pauseRenderDally->stop();
+    m_pauseRenderDally->start(1000);
 }
 
 ViewportWidget::~ViewportWidget()
@@ -556,8 +571,7 @@ void ViewportWidget::paintGL()
 void ViewportWidget::mousePressEvent(QMouseEvent* event)
 {
     if(event->button() == Qt::MidButton){
-        auto scene = Zenovis::GetInstance().getSession()->get_scene();
-        scene->drawOptions->simpleRender = true;
+        setSimpleRenderOption();
     }
     _base::mousePressEvent(event);
     m_camera->fakeMousePressEvent(event);
@@ -566,6 +580,8 @@ void ViewportWidget::mousePressEvent(QMouseEvent* event)
 
 void ViewportWidget::mouseMoveEvent(QMouseEvent* event)
 {
+    setSimpleRenderOption();
+
     _base::mouseMoveEvent(event);
     m_camera->fakeMouseMoveEvent(event);
     update();
@@ -573,17 +589,14 @@ void ViewportWidget::mouseMoveEvent(QMouseEvent* event)
 
 void ViewportWidget::wheelEvent(QWheelEvent* event)
 {
+    setSimpleRenderOption();
+
     _base::wheelEvent(event);
     m_camera->fakeWheelEvent(event);
     update();
 }
 
 void ViewportWidget::mouseReleaseEvent(QMouseEvent *event) {
-    if(event->button() == Qt::MidButton){
-        auto scene = Zenovis::GetInstance().getSession()->get_scene();
-        scene->drawOptions->simpleRender = false;
-    }
-
     _base::mouseReleaseEvent(event);
     m_camera->fakeMouseReleaseEvent(event); 
     update();

--- a/ui/zenoedit/viewport/viewportwidget.h
+++ b/ui/zenoedit/viewport/viewportwidget.h
@@ -85,6 +85,7 @@ public:
     void setPickTarget(const string& prim_name);
     void bindNodeToPicker(const QModelIndex& node, const QModelIndex& subgraph, const std::string& sock_name);
     void unbindNodeFromPicker();
+    void setSimpleRenderOption();
 
 signals:
     void frameRecorded(int);
@@ -102,6 +103,7 @@ private:
     std::shared_ptr<CameraControl> m_camera;
     QVector2D record_res;
     QPointF m_lastPos;
+    QTimer* m_pauseRenderDally;
 
 public:
     bool updateLightOnce;

--- a/zenovis/include/zenovis/DrawOptions.h
+++ b/zenovis/include/zenovis/DrawOptions.h
@@ -16,6 +16,7 @@ struct DrawOptions {
     bool smooth_shading = false;
     bool normal_check = false;
     bool simpleRender = false;
+    bool needRefresh = false;
     int num_samples = 1;
     int msaa_samples = 0;
 

--- a/zenovis/src/optx/RenderEngineOptx.cpp
+++ b/zenovis/src/optx/RenderEngineOptx.cpp
@@ -585,6 +585,7 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
     std::optional<decltype(std::tuple{MY_SIZE_ID(std::declval<Camera>())})> oldsizeid;
 
     bool ensuredshadtmpl = false;
+    bool needUpdateCamera = false;
     std::string shadtmpl;
     std::string_view commontpl;
     std::pair<std::string_view, std::string_view> shadtpl2;
@@ -628,7 +629,6 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
         auto guard = setupState();
         auto const &cam = *scene->camera;
         auto const &opt = *scene->drawOptions;
-        //zeno::log_info("test Optx::draw() options simpleRender {}", scene->drawOptions->simpleRender);
 
         bool sizeNeedUpdate = false;
         {
@@ -645,6 +645,13 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
                 camNeedUpdate = true;
             oldcamid = newcamid;
         }
+        if(scene->drawOptions->needRefresh){
+            camNeedUpdate = true;
+            scene->drawOptions->needRefresh = false;
+        }
+
+        //std::cout << "Render Options: SimpleRender " << scene->drawOptions->simpleRender
+        //          << " NeedRefresh " << scene->drawOptions->needRefresh << "\n";
 
         if (sizeNeedUpdate) {
             zeno::log_debug("[zeno-optix] updating resolution");

--- a/zenovis/xinxinoptix/DeflMatShader.cu
+++ b/zenovis/xinxinoptix/DeflMatShader.cu
@@ -454,7 +454,7 @@ extern "C" __global__ void __anyhit__shadow_cutout()
     auto sssParam = mats.sssParam;
     auto scatterStep = mats.scatterStep;
     unsigned short isLight = rt_data->lightMark[inst_idx * 1024 + prim_idx];
-    if(params.simpleRender==true)
+    if(params.simpleRender==true || prd->depth >= 3 )
         opacity = 0;
     //opacity = clamp(opacity, 0.0f, 0.99f);
     // Stochastic alpha test to get an alpha blend effect.

--- a/zenovis/xinxinoptix/PTKernel.cu
+++ b/zenovis/xinxinoptix/PTKernel.cu
@@ -125,6 +125,7 @@ extern "C" __global__ void __raygen__rg()
             vec3 radiance = vec3(prd.radiance);
             vec3 oldradiance = radiance;
             RadiancePRD shadow_prd;
+            shadow_prd.depth = prd.depth;
             shadow_prd.shadowAttanuation = make_float3(1.0f, 1.0f, 1.0f);
             shadow_prd.nonThinTransHit = prd.nonThinTransHit;
             traceOcclusion(params.handle, prd.LP, prd.Ldir,


### PR DESCRIPTION
当鼠标按下与滚轮移动时，触发一个定时器，将在1秒钟后设置SimpleRender为false，并且设置NeedRefresh为true，在optix的draw中判断NeedRefresh，当等于true时，将cameraNeedUpdate置为true，并将NeedRefresh设置回为false。