### PR TITLE
Fix frameid error

### DIFF
--- a/ui/zenoedit/viewport/zenovis.cpp
+++ b/ui/zenoedit/viewport/zenovis.cpp
@@ -120,10 +120,10 @@ void Zenovis::doFrameUpdate()
     //if fileio.isIOPathChanged() :
     //    core.clear_graphics()
 
-//    int frameid = getCurrentFrameId();
-    int frameid = zenoApp->getMainWindow()->getDisplayWidget()->getTimelinePointer()->value();
+    int frameid = getCurrentFrameId();
+    int ui_frameid = zenoApp->getMainWindow()->getDisplayWidget()->getTimelinePointer()->value();
 
-    zenoApp->getMainWindow()->doFrameUpdate(frameid);
+    zenoApp->getMainWindow()->doFrameUpdate(ui_frameid);
 
     if (m_playing) {
         zeno::log_trace("playing at frame {}", frameid);


### PR DESCRIPTION
修复doFrameUpdate中从ui获取的frameid误传入到了objectsUpdated信号中