### PR TITLE
Noiseupdate and deg/rad convert

### DIFF
--- a/misc/graphs/GaborNoise.zsg
+++ b/misc/graphs/GaborNoise.zsg
@@ -1,0 +1,29371 @@
+{
+    "graph": {
+        "main": {
+            "nodes": {
+                "5fd81908-Make2DGridPrimitive": {
+                    "name": "Make2DGridPrimitive",
+                    "inputs": {
+                        "nx": {
+                            "link": null,
+                            "default-value": 500,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "ny": {
+                            "link": null,
+                            "default-value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "sizeX": {
+                            "link": null,
+                            "default-value": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "sizeY": {
+                            "link": null,
+                            "default-value": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "scale": {
+                            "link": null,
+                            "default-value": 1000.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "origin": {
+                            "link": null,
+                            "default-value": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "Direction": {
+                            "value": "XZ",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "XZ",
+                                    "XY",
+                                    "YZ"
+                                ]
+                            },
+                            "type": "enum XZ XY YZ"
+                        },
+                        "hasFaces": {
+                            "value": true,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "isCentered": {
+                            "value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        }
+                    },
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -9148.0,
+                        -652.4000000000002
+                    ],
+                    "options": []
+                },
+                "515695f4-GaborNoise": {
+                    "name": "GaborNoise",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "prim": {
+                            "link": "main:5fd81908-Make2DGridPrimitive:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "ElementSize": {
+                            "link": null,
+                            "default-value": 15,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "Scale": {
+                            "link": null,
+                            "default-value": [
+                                1.0,
+                                1.0,
+                                1.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "isotropic": {
+                            "link": null,
+                            "default-value": true,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "Impulse per kernel": {
+                            "link": null,
+                            "default-value": 512,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "a_": {
+                            "link": null,
+                            "default-value": 0.019999999552965165,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "noiseseed": {
+                            "link": null,
+                            "default-value": 12,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "int"
+                        },
+                        "offset": {
+                            "link": null,
+                            "default-value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "frequency": {
+                            "link": null,
+                            "default-value": 0.20000000298023225,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "Orientation": {
+                            "link": null,
+                            "default-value": 0.5,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "DST": {},
+                        "prim": {}
+                    },
+                    "uipos": [
+                        -8389.8671875,
+                        -666.4000000000002
+                    ],
+                    "options": [
+                        "VIEW"
+                    ],
+                    "customui-panel": {
+                        "Default": {
+                            "In Sockets": {
+                                "SRC": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/SRC",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 2816753741
+                                },
+                                "prim": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/prim",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 1183632032
+                                },
+                                "ElementSize": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/ElementSize",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 3568526265
+                                },
+                                "Scale": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/Scale",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float Vector 3"
+                                    },
+                                    "uuid": 2368355282
+                                },
+                                "noiseseed": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/noiseseed",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float"
+                                    },
+                                    "uuid": 3866951673
+                                },
+                                "isotropic": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/isotropic",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Boolean"
+                                    },
+                                    "uuid": 2038060998
+                                },
+                                "Impulse per kernel": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/Impulse per kernel",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 1754837282
+                                },
+                                "frequency": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/frequency",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float"
+                                    },
+                                    "uuid": 2530381277
+                                },
+                                "Orientation": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/Orientation",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float"
+                                    },
+                                    "uuid": 2417648977
+                                },
+                                "a_": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/a_",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float"
+                                    },
+                                    "uuid": 3161084629
+                                },
+                                "offset": {
+                                    "core-param": {
+                                        "name": "main:515695f4-GaborNoise:[node]/inputs/offset",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 178333203
+                                }
+                            },
+                            "Parameters": {},
+                            "Out Sockets": {
+                                "DST": {
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 3800585735
+                                },
+                                "prim": {
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 541239170
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "view_rect": {}
+        },
+        "GaborNoise": {
+            "nodes": {
+                "3962a06d-ParticlesWrangle": {
+                    "name": "ParticlesWrangle",
+                    "inputs": {
+                        "prim": {
+                            "link": "GaborNoise:e5c08c8b-Noise_gabor_2d:[node]/outputs/prim_2DGrid",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "PrimitiveObject"
+                        },
+                        "zfxCode": {
+                            "link": null,
+                            "default-value": "@pos = @orignalPos\n@clr = (@noise + 1)*0.75\n\n\n",
+                            "control": {
+                                "name": "Multiline String"
+                            },
+                            "type": "string"
+                        },
+                        "params": {
+                            "property": "dict-panel",
+                            "dictlist-panel": {
+                                "collasped": false,
+                                "keys": {}
+                            },
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "dict"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -332.826416015625,
+                        -107.724609375
+                    ],
+                    "options": []
+                },
+                "71135746-PrimitiveDelAttr": {
+                    "name": "PrimitiveDelAttr",
+                    "inputs": {
+                        "prim": {
+                            "link": "GaborNoise:3962a06d-ParticlesWrangle:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "name": {
+                            "value": "orignalPos",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        394.999755859375,
+                        564.0
+                    ],
+                    "options": []
+                },
+                "7eb43cef-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": [
+                                1.0,
+                                1.0,
+                                1.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "name": {
+                            "value": "Scale",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "vec3f",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -4975.33349609375,
+                        581.6666259765625
+                    ],
+                    "options": []
+                },
+                "94b4408d-ParticlesWrangle": {
+                    "name": "ParticlesWrangle",
+                    "inputs": {
+                        "prim": {
+                            "link": "GaborNoise:dc9ae304-SubInput:[node]/outputs/port",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "PrimitiveObject"
+                        },
+                        "zfxCode": {
+                            "link": null,
+                            "default-value": "@orignalPos = @pos\n\nfrequency = 1 / ($elesize * $scale + 0.00001)\noffset = $offset * frequency\n\ntemp_pos = @pos * frequency + offset\n\n@pos = temp_pos\n@clr = vec3(1,1,1)\n",
+                            "control": {
+                                "name": "Multiline String"
+                            },
+                            "type": "string"
+                        },
+                        "params": {
+                            "property": "dict-panel",
+                            "dictlist-panel": {
+                                "collasped": false,
+                                "keys": {
+                                    "elesize": {
+                                        "link": "GaborNoise:bc0e6915-SubInput:[node]/outputs/port"
+                                    },
+                                    "scale": {
+                                        "link": "GaborNoise:7eb43cef-SubInput:[node]/outputs/port"
+                                    },
+                                    "offset": {
+                                        "link": "GaborNoise:b4288dea-SubInput:[node]/outputs/port"
+                                    }
+                                }
+                            },
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "dict"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -3122.375732421875,
+                        -257.7917175292969
+                    ],
+                    "options": []
+                },
+                "9846689d-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 15.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "name": {
+                            "value": "noiseseed",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "float",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -2588.33349609375,
+                        968.0
+                    ],
+                    "options": []
+                },
+                "bc0e6915-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 10,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "ElementSize",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -4135.33349609375,
+                        -12.0
+                    ],
+                    "options": []
+                },
+                "beb92ce4-SubOutput": {
+                    "name": "SubOutput",
+                    "inputs": {
+                        "port": {
+                            "link": "GaborNoise:71135746-PrimitiveDelAttr:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": "",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "name": {
+                            "value": "prim",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "string",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "DST": {}
+                    },
+                    "uipos": [
+                        1641.3330078125,
+                        102.6666259765625
+                    ],
+                    "options": []
+                },
+                "dc9ae304-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": "",
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "name": {
+                            "value": "prim",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -4717.33349609375,
+                        -690.0
+                    ],
+                    "options": []
+                },
+                "e5c08c8b-Noise_gabor_2d": {
+                    "name": "Noise_gabor_2d",
+                    "inputs": {
+                        "prim_2DGrid": {
+                            "link": "GaborNoise:94b4408d-ParticlesWrangle:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "posLikeAttrName": {
+                            "link": null,
+                            "default-value": "pos",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "a_": {
+                            "link": "GaborNoise:8db5fb77-SubInput:[node]/outputs/port",
+                            "default-value": 0.05000000074505806,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "frequency": {
+                            "link": "GaborNoise:ca9bd71b-SubInput:[node]/outputs/port",
+                            "default-value": 0.20000000298023225,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "Orientation": {
+                            "link": "GaborNoise:318a3a5f-SubInput:[node]/outputs/port",
+                            "default-value": 0.800000011920929,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "impulses_per_kernel": {
+                            "link": "GaborNoise:57b3f6b9-SubInput:[node]/outputs/port",
+                            "default-value": 64,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "isotropic": {
+                            "link": "GaborNoise:437b8625-SubInput:[node]/outputs/port",
+                            "default-value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "offset": {
+                            "link": "GaborNoise:9846689d-SubInput:[node]/outputs/port",
+                            "default-value": 15.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "attrName": {
+                            "value": "noise",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "prim_2DGrid": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -1360.0,
+                        35.0
+                    ],
+                    "options": []
+                },
+                "ca9bd71b-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0.20000000298023225,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "name": {
+                            "value": "frequency",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "float",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -2622.666748046875,
+                        -970.0
+                    ],
+                    "options": []
+                },
+                "8db5fb77-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0.05000000074505806,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "name": {
+                            "value": "a_",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "float",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -3275.666748046875,
+                        -863.3333129882813
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                },
+                "318a3a5f-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0.800000011920929,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "name": {
+                            "value": "Orientation",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "float",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -2006.3333740234376,
+                        -901.0
+                    ],
+                    "options": []
+                },
+                "57b3f6b9-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 64,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "Impulse per kernel",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -2305.0,
+                        385.3333740234375
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                },
+                "437b8625-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "name": {
+                            "value": "isotropic",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "bool",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -2261.33349609375,
+                        704.0
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                },
+                "b4288dea-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "offset",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -4028.0,
+                        888.0
+                    ],
+                    "options": []
+                },
+                "24baea-Blackboard": {
+                    "name": "Blackboard",
+                    "inputs": {},
+                    "params": {},
+                    "outputs": {},
+                    "uipos": [
+                        -1951.86669921875,
+                        1349.13330078125
+                    ],
+                    "options": [],
+                    "blackboard": {
+                        "special": false,
+                        "width": 500.0,
+                        "height": 510.0,
+                        "title": "title",
+                        "content": "a 0.005-0.1  F 0.01-0.3  omega 0.0-M_PI"
+                    }
+                },
+                "827f4939-Noise_gabor_2d": {
+                    "name": "Noise_gabor_2d",
+                    "inputs": {
+                        "prim_2DGrid": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "posLikeAttrName": {
+                            "link": null,
+                            "default-value": "pos",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "a_": {
+                            "link": null,
+                            "default-value": 0.07000000029802323,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "frequency": {
+                            "link": null,
+                            "default-value": 0.20000000298023225,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "Orientation": {
+                            "link": null,
+                            "default-value": 0.800000011920929,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "impulses_per_kernel": {
+                            "link": null,
+                            "default-value": 64,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "isotropic": {
+                            "link": null,
+                            "default-value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "offset": {
+                            "link": null,
+                            "default-value": 15.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "attrName": {
+                            "value": "noise",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "prim_2DGrid": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -993.6000000000003,
+                        1059.2
+                    ],
+                    "options": []
+                }
+            },
+            "view_rect": {}
+        }
+    },
+    "views": {
+        "timeline": {
+            "start-frame": 0,
+            "end-frame": 0,
+            "curr-frame": 0,
+            "always": false
+        }
+    },
+    "descs": {
+        "AABBCollideDetect": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "bminA",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxA",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminB",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "overlap",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "AinsideB",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "BinsideA",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "AABBVoronoi": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bboxMin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bboxMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "numRandPoints",
+                    "64"
+                ],
+                [
+                    "bool",
+                    "periodicX",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicY",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicZ",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "AppendList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "Assign": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "AudioBeats": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "beat",
+                    ""
+                ],
+                [
+                    "",
+                    "var_H",
+                    ""
+                ],
+                [
+                    "",
+                    "H",
+                    ""
+                ],
+                [
+                    "",
+                    "E",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioEnergy": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "beat",
+                    ""
+                ],
+                [
+                    "",
+                    "E",
+                    ""
+                ],
+                [
+                    "",
+                    "uniE",
+                    ""
+                ],
+                [
+                    "",
+                    "minE",
+                    ""
+                ],
+                [
+                    "",
+                    "maxE",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioFFT": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "bool",
+                    "preEmphasis",
+                    "0"
+                ],
+                [
+                    "float",
+                    "preEmphasisAlpha",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hammingWindow",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioPowerVariation": {
+            "inputs": [
+                [
+                    "float",
+                    "sumpower",
+                    ""
+                ],
+                [
+                    "int",
+                    "winwidth",
+                    "20"
+                ],
+                [
+                    "int",
+                    "scale",
+                    "1"
+                ],
+                [
+                    "int",
+                    "maximum",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "powvar",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioSumPower": {
+            "inputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "sumpower",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "BVHNearestAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "string",
+                    "bvhIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "bvhWeightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "string",
+                    "bvhAttrTag",
+                    "bvh_attr"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "BVHNearestPos": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "string",
+                    "bvhIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "bvhWeightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "string",
+                    "bvhPosTag",
+                    "bvh_pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "BackupField": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "BecomeRtInst": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isInst",
+                    "1"
+                ],
+                [
+                    "string",
+                    "instID",
+                    "Inst1"
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BeginFor": {
+            "inputs": [
+                [
+                    "int",
+                    "count",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BeginForEach": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BeginSubstep": {
+            "inputs": [
+                [
+                    "float",
+                    "total_dt",
+                    ""
+                ],
+                [
+                    "float",
+                    "min_scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "float",
+                    "elapsed_time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BindLight": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "islight",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "invertdir",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BindMaterial": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "mtlid",
+                    "Mat1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BindRtInst": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "instID",
+                    "Inst1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "Blackboard": {
+            "inputs": [],
+            "params": [],
+            "outputs": [],
+            "categories": [
+                "layout"
+            ]
+        },
+        "BoundingBoxFitInto": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "bminSrc",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxSrc",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminDst",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxDst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminTrans",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxTrans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "BreakFor": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "bool",
+                    "breaks",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BuildPrimitiveBvh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "thickness",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum auto point line tri quad",
+                    "prim_type",
+                    "auto"
+                ]
+            ],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "BulletCalcInverseKinematics": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "endEffectorLinkIndices",
+                    ""
+                ],
+                [
+                    "",
+                    "targetPositions",
+                    ""
+                ],
+                [
+                    "",
+                    "targetOrientations",
+                    ""
+                ],
+                [
+                    "int",
+                    "numIterations",
+                    "20"
+                ],
+                [
+                    "float",
+                    "residualThreshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum VEL_DLS_ORI_NULL VEL_SDLS_ORI VEL_DLS_ORI VEL_DLS_NULL VEL_SDLS VEL_DLS JACOB_TRANS",
+                    "IKMethod",
+                    "VEL_DLS_ORI_NULL"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "poses",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletColShapeCalcLocalInertia": {
+            "inputs": [
+                [
+                    "",
+                    "colObject",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isCompound",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "localInertia",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletComposeTransform": {
+            "inputs": [
+                [
+                    "",
+                    "transFirst",
+                    ""
+                ],
+                [
+                    "",
+                    "transSecond",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletCompoundAddChild": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "childShape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintDisplay": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "nlist",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintGetFrames": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "frame1",
+                    ""
+                ],
+                [
+                    "",
+                    "frame2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetAxis": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "axis1",
+                    ""
+                ],
+                [
+                    "",
+                    "axis2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Fixed Gear Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Point2Point Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetBreakThres": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetFrames": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "frame1",
+                    ""
+                ],
+                [
+                    "",
+                    "frame2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetLimitByAxis": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "lowLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "highLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetMotor": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "bounce",
+                    ""
+                ],
+                [
+                    "bool",
+                    "enableMotor",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "enableServo",
+                    "1"
+                ],
+                [
+                    "float",
+                    "maxMotorForce",
+                    ""
+                ],
+                [
+                    "float",
+                    "servoTarget",
+                    ""
+                ],
+                [
+                    "float",
+                    "targetVelocity",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulse",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulseNormalized",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "motorTarget",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "motorTargetConstraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "angularOnly",
+                    ""
+                ],
+                [
+                    "float",
+                    "fixThresh",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum ConeTwist Generic6Dof Generic6DofSpring2 Hinge Hinge2",
+                    "constraintType",
+                    "ConeTwist"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetRefFrameA": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Generic6Dof Generic6DofSpring Hinge Universal",
+                    "constraintType",
+                    "Universal"
+                ],
+                [
+                    "enum true false",
+                    "useReferenceFrameA",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetRotOrder": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Generic6DofSpring2 Hinge2",
+                    "constraintType",
+                    "Hinge2"
+                ],
+                [
+                    "enum XYZ XZY YXZ YZX ZXY ZYX",
+                    "rotateOrder",
+                    "XYZ"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetSpring": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "bool",
+                    "enable",
+                    "0"
+                ],
+                [
+                    "",
+                    "stiffness",
+                    ""
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "equilibriumPointVal",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum Fixed Generic6DofSpring Generic6DofSpring2 Hinge2",
+                    "constraintType",
+                    "Fixed"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletExtractTransform": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGearConstraintSetRatio": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "ratio",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGetAABB": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "aabbMin",
+                    ""
+                ],
+                [
+                    "",
+                    "aabbMax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGlueCompoundAddChild": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "childShape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGlueCompoundUpdateGlueList": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "glueListVec2i",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletInverseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans_inv",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeBoxShape": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "semiSize",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCapsuleShape": {
+            "inputs": [
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCompoundShape": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "int",
+                    "iternum",
+                    "100"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Gear Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Point2Point Slider Universal",
+                    "constraintType",
+                    "Fixed"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConvexHullShape": {
+            "inputs": [
+                [
+                    "",
+                    "triMesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "margin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConvexMeshShape": {
+            "inputs": [
+                [
+                    "",
+                    "triMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCylinderShape": {
+            "inputs": [
+                [
+                    "",
+                    "halfExtents",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeFrameFromPivotAxis": {
+            "inputs": [
+                [
+                    "",
+                    "pivot",
+                    ""
+                ],
+                [
+                    "",
+                    "axis",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "frame",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeGlueCompoundShape": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeMultiBodyWorld": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum SequentialImpulse ProjectedGaussSeidel Dantzig",
+                    "solverType",
+                    "SequentialImpulse"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeObject": {
+            "inputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeSphereShape": {
+            "inputs": [
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeStaticPlaneShape": {
+            "inputs": [
+                [
+                    "",
+                    "planeNormal",
+                    ""
+                ],
+                [
+                    "float",
+                    "planeConstant",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeTransform": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "translate",
+                    ""
+                ],
+                [
+                    "",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeWorld": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyAddJointTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyApplyExternalForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "force",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyApplyExternalTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyCalculateJacobian": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "localPos",
+                    ""
+                ],
+                [
+                    "",
+                    "jointPositionsQ",
+                    ""
+                ],
+                [
+                    "",
+                    "jointVelocitiesQd",
+                    ""
+                ],
+                [
+                    "",
+                    "jointAccelerations",
+                    ""
+                ],
+                [
+                    "",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jacobian_linear",
+                    ""
+                ],
+                [
+                    "",
+                    "jacobian_angular",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyCalculateMassMatrix": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jointPositionsQ",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "mass_matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyClearJointStates": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyForwardKinematics": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBaseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBaseVelocity": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBodyId": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "id",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetContactPoints": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "contactPointsList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetJointTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jointIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetJointVelPos": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vel",
+                    ""
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetLinkForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "force",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetLinkTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetNumBodies": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "numBodies",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyLinkColliderSetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyLinkGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyMakeConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "bodyA",
+                    ""
+                ],
+                [
+                    "",
+                    "linkA",
+                    ""
+                ],
+                [
+                    "",
+                    "bodyB",
+                    ""
+                ],
+                [
+                    "",
+                    "linkB",
+                    ""
+                ],
+                [
+                    "",
+                    "lowerLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "upperLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "twistLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "jointMaxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "desiredVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Default DefaultMotor Spherical SphericalMotor Fixed Gear Point2Point Slider",
+                    "constraintType",
+                    "Default"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyMakeJointMotor": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "int",
+                    "linkDof",
+                    "0"
+                ],
+                [
+                    "float",
+                    "desiredVelocity",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulse",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyObjectMakeEnd": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyObjectMakeStart": {
+            "inputs": [
+                [
+                    "",
+                    "nLinks",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "inertia",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "canSleep",
+                    "true"
+                ],
+                [
+                    "enum true false",
+                    "fixedBase",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyPDControl": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "kp",
+                    ""
+                ],
+                [
+                    "float",
+                    "kd",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "qDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "dqDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyRemoveBody": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "id",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyResetSimulation": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetBaseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "baseTrans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetCollider": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetCollisionShapeForLink": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "colShape",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointFeedback": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointPosMultiDof": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "startIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isSpherical",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointProperty": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "linkIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "friction",
+                    ""
+                ],
+                [
+                    "",
+                    "lowerLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "upperLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "maxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "maxVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointVelMultiDof": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "startIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isSpherical",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetProperty": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "linearDamp",
+                    ""
+                ],
+                [
+                    "float",
+                    "angularDamp",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "canSleep",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "selfCollide",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "useGyro",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetupJoint": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "parentIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "inertia",
+                    ""
+                ],
+                [
+                    "",
+                    "jointAxis",
+                    ""
+                ],
+                [
+                    "",
+                    "rotParentToThis",
+                    ""
+                ],
+                [
+                    "",
+                    "parentComToThisPivotOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "thisPivotToThisComOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "disableParentCollision",
+                    "false"
+                ],
+                [
+                    "enum Fixed Prismatic Revolute Spherical Planar",
+                    "jointType",
+                    "Revolute"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyUpdateColObjectTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddCollisionObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isDynamic",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddConstraintEnd": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum rigid multi",
+                    "objType",
+                    "multi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldGetTransformShapes": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "visualMap",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transList",
+                    ""
+                ],
+                [
+                    "",
+                    "visualList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldRemoveConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldRemoveObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum rigid multi",
+                    "objType",
+                    "multi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldSetGravity": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectApplyForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "ForceImpulse",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "TorqueImpulse",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectGetVel": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "linearVel",
+                    ""
+                ],
+                [
+                    "",
+                    "angularVel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetDamping": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "dampLin",
+                    ""
+                ],
+                [
+                    "float",
+                    "dampAug",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetFriction": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "friction",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetRestitution": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "restitution",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletQuatRotate": {
+            "inputs": [
+                [
+                    "",
+                    "quat",
+                    ""
+                ],
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletResetSimulation": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletSetContactParameters": {
+            "inputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "lateralFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "restitution",
+                    ""
+                ],
+                [
+                    "",
+                    "rollingFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "spinningFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "stiffness",
+                    ""
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "frictionAnchor",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "BulletSliderConstraintSetSpring": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "maxAngMotorForce",
+                    ""
+                ],
+                [
+                    "",
+                    "maxLinMotorForce",
+                    ""
+                ],
+                [
+                    "",
+                    "poweredAngMotor",
+                    ""
+                ],
+                [
+                    "",
+                    "poweredLinMotor",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "targetAngMotorVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "targetLinMotorVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletStepMultiBodyWorld": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "int",
+                    "maxSubSteps",
+                    "1"
+                ],
+                [
+                    "float",
+                    "fixedTimeStep",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletStepWorld": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "int",
+                    "steps",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletTransformSetBasisEuler": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "eulerZYX",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldAddConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldAddObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldRemoveConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldRemoveObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetConsList": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "consList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetGravity": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetObjList": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "objList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "CacheLastFrameBegin": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "linkFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "lastFrame",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CacheLastFrameEnd": {
+            "inputs": [
+                [
+                    "",
+                    "linkTo",
+                    ""
+                ],
+                [
+                    "",
+                    "updateCache",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CachePrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "inPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "dir",
+                    "/tmp/cache"
+                ],
+                [
+                    "bool",
+                    "ignore",
+                    "0"
+                ],
+                [
+                    "string",
+                    "prefix",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CacheVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "inGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "dir",
+                    "/tmp/cache"
+                ],
+                [
+                    "bool",
+                    "ignore",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "mute",
+                    "0"
+                ],
+                [
+                    "string",
+                    "prefix",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CachedByKey": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CachedIf": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "keepCache",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CachedOnce": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CalcDirectionFromAngle": {
+            "inputs": [
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "enum XY YX YZ ZY ZX XZ",
+                    "plane",
+                    "XY"
+                ],
+                [
+                    "float",
+                    "length",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "CalcGeometryUV": {
+            "inputs": [
+                [
+                    "readpath",
+                    "objpath",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "CalculateResidual2": {
+            "inputs": [
+                [
+                    "",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "CameraEval": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "nodelist",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Bezier Linear ",
+                    "inter",
+                    "Bezier"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "CameraNode": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "string",
+                    "other",
+                    ""
+                ],
+                [
+                    "int",
+                    "frame",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "CameraObject",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "CihouMayaCameraFov": {
+            "inputs": [
+                [
+                    "enum Horizontal Vertical",
+                    "fit_gate",
+                    "Horizontal"
+                ],
+                [
+                    "float",
+                    "focL",
+                    ""
+                ],
+                [
+                    "float",
+                    "fw",
+                    ""
+                ],
+                [
+                    "float",
+                    "fh",
+                    ""
+                ],
+                [
+                    "float",
+                    "nx",
+                    ""
+                ],
+                [
+                    "float",
+                    "ny",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "Clone": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "newObject",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "CombineVDB": {
+            "inputs": [
+                [
+                    "",
+                    "FieldA",
+                    ""
+                ],
+                [
+                    "",
+                    "FieldB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "MultiplierA",
+                    ""
+                ],
+                [
+                    "float",
+                    "MultiplierB",
+                    ""
+                ],
+                [
+                    "enum CSGUnion CSGIntersection CSGDifference Add Mul Replace A_Sample_B",
+                    "OpType",
+                    "CSGUnion"
+                ],
+                [
+                    "bool",
+                    "writeBack",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "FieldOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "CompressibleAdvection": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "RK_Order",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CompressibleMarkDOF": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CompressibleProjection": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "RK_Order",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CopyAllUserData": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "CreateBezierCurve": {
+            "inputs": [
+                [
+                    "list",
+                    "CustomPoints",
+                    ""
+                ],
+                [
+                    "prim",
+                    "SamplePoints",
+                    ""
+                ],
+                [
+                    "float",
+                    "precision",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "SampleAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "SampleTag",
+                    ""
+                ],
+                [
+                    "enum Bezier",
+                    "Type",
+                    "Bezier"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "curev",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCircle": {
+            "inputs": [
+                [
+                    "int",
+                    "segments",
+                    "32"
+                ],
+                [
+                    "float",
+                    "r",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "CreateCone": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "lons",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCube": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "int",
+                    "div_w",
+                    "2"
+                ],
+                [
+                    "int",
+                    "div_h",
+                    "2"
+                ],
+                [
+                    "int",
+                    "div_d",
+                    "2"
+                ],
+                [
+                    "float",
+                    "size",
+                    ""
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCylinder": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "lons",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateDisk": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "int",
+                    "divisions",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreatePlane": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "size",
+                    ""
+                ],
+                [
+                    "int",
+                    "rows",
+                    "1"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreatePoint": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateSphere": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "int",
+                    "rows",
+                    "12"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "24"
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateTube": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "radius1",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius2",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "rows",
+                    "3"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "12"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CurveOrientation": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirName",
+                    "dir"
+                ],
+                [
+                    "string",
+                    "tanName",
+                    "tan"
+                ],
+                [
+                    "string",
+                    "bitanName",
+                    "bitan"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Curvemap": {
+            "inputs": [
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "res",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "DegreetoRad": {
+            "inputs": [
+                [
+                    "float",
+                    "degree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "radian",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "DelUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "DemBones": {
+            "inputs": [
+                [
+                    "",
+                    "BakedPrimList",
+                    ""
+                ],
+                [
+                    "",
+                    "RefPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "bone_number",
+                    "20"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "BoneBindInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "SkiningInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "FrameInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "DemBones"
+            ]
+        },
+        "DenseFieldToVDB": {
+            "inputs": [
+                [
+                    "",
+                    "inDenseField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "VDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "DictEraseItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictGetItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "defl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "zany",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictGetKeyList": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ListObject",
+                    "keys",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictHasKey": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "hasKey",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictSetItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "zany",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictSize": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictUnion": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict1",
+                    ""
+                ],
+                [
+                    "DictObject",
+                    "dict2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DynamicNumber": {
+            "inputs": [
+                [
+                    "",
+                    "frame",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum 100 10 1 0.1 0.01 0.001",
+                    "speed",
+                    "1"
+                ],
+                [
+                    "enum clamp zero cycle",
+                    "type",
+                    "clamp"
+                ],
+                [
+                    "floatslider",
+                    "w",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "x",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "y",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "z",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "x",
+                    ""
+                ],
+                [
+                    "",
+                    "y",
+                    ""
+                ],
+                [
+                    "",
+                    "z",
+                    ""
+                ],
+                [
+                    "",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "EmptyDict": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "EmptyList": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "EndFor": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "EndForEach": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "accept",
+                    "1"
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doConcat",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "droppedList",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "EvalCurve": {
+            "inputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "EvalCurveOnPrimAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "dstName",
+                    ""
+                ],
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "EvalFBXAnim": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "float",
+                    "fps",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum TRUE FALSE",
+                    "interAnimData",
+                    "FALSE"
+                ],
+                [
+                    "bool",
+                    "printAnimData",
+                    "0"
+                ],
+                [
+                    "enum FROM_MAYA DEFAULT",
+                    "unit",
+                    "FROM_MAYA"
+                ],
+                [
+                    "bool",
+                    "writeData",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "light",
+                    ""
+                ],
+                [
+                    "",
+                    "matName",
+                    ""
+                ],
+                [
+                    "",
+                    "meshName",
+                    ""
+                ],
+                [
+                    "",
+                    "bsPrims",
+                    ""
+                ],
+                [
+                    "",
+                    "bsPrimsOrigin",
+                    ""
+                ],
+                [
+                    "",
+                    "transDict",
+                    ""
+                ],
+                [
+                    "",
+                    "quatDict",
+                    ""
+                ],
+                [
+                    "",
+                    "scaleDict",
+                    ""
+                ],
+                [
+                    "",
+                    "writeData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExchangeFBXData": {
+            "inputs": [
+                [
+                    "",
+                    "d",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum DATA DATAS MATS",
+                    "dType",
+                    "DATA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "d",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExportFBX": {
+            "inputs": [
+                [
+                    "string",
+                    "custom_command",
+                    ""
+                ],
+                [
+                    "string",
+                    "extra_param",
+                    " -b=5"
+                ],
+                [
+                    "string",
+                    "abcpath",
+                    ""
+                ],
+                [
+                    "string",
+                    "fbxpath",
+                    ""
+                ],
+                [
+                    "string",
+                    "outpath",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExportObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportParticles": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportUVObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "ExportVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportZpmPrimitive": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExtendList": {
+            "inputs": [
+                [
+                    "",
+                    "list1",
+                    ""
+                ],
+                [
+                    "",
+                    "list2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list1",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ExtractAxis": {
+            "inputs": [
+                [
+                    "AxisObject",
+                    "math",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisZ",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "ExtractCameraData": {
+            "inputs": [
+                [
+                    "string",
+                    "key",
+                    "camera1"
+                ],
+                [
+                    "",
+                    "camobject",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "up",
+                    ""
+                ],
+                [
+                    "",
+                    "view",
+                    ""
+                ],
+                [
+                    "",
+                    "focL",
+                    ""
+                ],
+                [
+                    "",
+                    "haov",
+                    ""
+                ],
+                [
+                    "",
+                    "waov",
+                    ""
+                ],
+                [
+                    "",
+                    "hfov",
+                    ""
+                ],
+                [
+                    "",
+                    "filmW",
+                    ""
+                ],
+                [
+                    "",
+                    "filmH",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "ExtractFBXData": {
+            "inputs": [
+                [
+                    "FBXData",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IVertices",
+                    "vertices",
+                    ""
+                ],
+                [
+                    "IIndices",
+                    "indices",
+                    ""
+                ],
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "IBoneOffset",
+                    "boneOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractLegacyDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExtractList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ExtractMatData": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum V1 V2",
+                    "texVer",
+                    "V1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "datas",
+                    ""
+                ],
+                [
+                    "",
+                    "matName",
+                    ""
+                ],
+                [
+                    "",
+                    "texLists",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatDict": {
+            "inputs": [
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mats",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatName": {
+            "inputs": [
+                [
+                    "",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "name",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatTexList": {
+            "inputs": [
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "texLists",
+                    ""
+                ],
+                [
+                    "",
+                    "name",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "FFPlayAudioFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "bool",
+                    "nodisp",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "wait",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "FileReadString": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "FileWriteString": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "FuncBegin": {
+            "inputs": [
+                [
+                    "",
+                    "extraArgs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncCall": {
+            "inputs": [
+                [
+                    "FunctionObject",
+                    "function",
+                    ""
+                ],
+                [
+                    "FunctionObject",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "FunctionObject",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncCallInDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "funcDict",
+                    ""
+                ],
+                [
+                    "bool",
+                    "mayNotFound",
+                    "1"
+                ],
+                [
+                    "string",
+                    "dictKey",
+                    ""
+                ],
+                [
+                    "DictObject",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncEnd": {
+            "inputs": [
+                [
+                    "",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleBegin": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "arg",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleCall": {
+            "inputs": [
+                [
+                    "FunctionObject",
+                    "function",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "arg",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleCallInDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "funcDict",
+                    ""
+                ],
+                [
+                    "string",
+                    "dictKey",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "arg",
+                    ""
+                ],
+                [
+                    "bool",
+                    "mayNotFound",
+                    "1"
+                ],
+                [
+                    "IObject",
+                    "notFoundRet",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "isFound",
+                    "0"
+                ],
+                [
+                    "IObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleEnd": {
+            "inputs": [
+                [
+                    "",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "GaborNoise": {
+            "inputs": {
+                "SRC": {
+                    "default-value": null,
+                    "control": {
+                        "name": ""
+                    },
+                    "type": ""
+                },
+                "prim": {
+                    "default-value": null,
+                    "control": {
+                        "name": ""
+                    },
+                    "type": ""
+                },
+                "ElementSize": {
+                    "default-value": 10,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "Scale": {
+                    "default-value": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ],
+                    "control": {
+                        "name": "Float Vector 3"
+                    },
+                    "type": "vec3f"
+                },
+                "isotropic": {
+                    "default-value": false,
+                    "control": {
+                        "name": "Boolean"
+                    },
+                    "type": "bool"
+                },
+                "Impulse per kernel": {
+                    "default-value": 64,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "a_": {
+                    "default-value": 0.05000000074505806,
+                    "control": {
+                        "name": "Float"
+                    },
+                    "type": "float"
+                },
+                "noiseseed": {
+                    "default-value": null,
+                    "control": {
+                        "name": "Float"
+                    },
+                    "type": "int"
+                },
+                "offset": {
+                    "default-value": 0,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "frequency": {
+                    "default-value": 0.20000000298023225,
+                    "control": {
+                        "name": "Float"
+                    },
+                    "type": "float"
+                },
+                "Orientation": {
+                    "default-value": 0.800000011920929,
+                    "control": {
+                        "name": "Float"
+                    },
+                    "type": "float"
+                }
+            },
+            "params": {},
+            "outputs": {
+                "DST": {},
+                "prim": {}
+            },
+            "categories": [
+                "subgraph"
+            ],
+            "is_subgraph": true
+        },
+        "Gather2DFiniteDifference": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "string",
+                    "channel",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum FIVE_STENCIL NINE_STENCIL",
+                    "OpType",
+                    "FIVE_STENCIL"
+                ],
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "GeoVertexVel": {
+            "inputs": [
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "TargetMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "OriginMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "MeshVel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "GetCurveControlPoint": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "point_x",
+                    ""
+                ],
+                [
+                    "float",
+                    "point_y",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "left_handler",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "right_handler",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "GetDenseField": {
+            "inputs": [
+                [
+                    "",
+                    "inSolverData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "FieldName",
+                    "p u rho"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outDenseField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "GetFrameNum": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FrameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFramePortion": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FramePortion",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFrameTimeElapsed": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetPerlinNoise": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "freq",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "noise",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "noise"
+            ]
+        },
+        "GetTime": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasValue",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "GetVDBBound": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "GetVDBPoints": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "GetVDBPointsDroplets": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "GetVDBVoxelSize": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dx",
+                    ""
+                ],
+                [
+                    "",
+                    "dy",
+                    ""
+                ],
+                [
+                    "",
+                    "dz",
+                    ""
+                ],
+                [
+                    "",
+                    "dxyz",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "Grid2DSample": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "float",
+                    "h",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "string",
+                    "channel",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "sampleBy",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "Group": {
+            "inputs": [],
+            "params": [],
+            "outputs": [],
+            "categories": [
+                "layout"
+            ]
+        },
+        "HDRSky": {
+            "inputs": [
+                [
+                    "bool",
+                    "enable",
+                    "1"
+                ],
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "float",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotation3d",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "HDRSky",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "HeightStarPattern": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "float",
+                    "anglerandom",
+                    ""
+                ],
+                [
+                    "float",
+                    "shapesize",
+                    ""
+                ],
+                [
+                    "float",
+                    "posjitter",
+                    ""
+                ],
+                [
+                    "float",
+                    "sharpness",
+                    ""
+                ],
+                [
+                    "float",
+                    "starness",
+                    ""
+                ],
+                [
+                    "int",
+                    "sides",
+                    "5"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "HelperMute": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "NOTE",
+                    "Dont-use-this-node-directly"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "HelperOnce": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "NOTE",
+                    "Dont-use-this-node-directly"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "INTERN_PreViewVDB": {
+            "inputs": [
+                [
+                    "",
+                    "arg0",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "ret0",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "IfElse": {
+            "inputs": [
+                [
+                    "",
+                    "true",
+                    ""
+                ],
+                [
+                    "",
+                    "false",
+                    ""
+                ],
+                [
+                    "bool",
+                    "cond",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "ImportObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportObjPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportParticles": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportZpmPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "InitField": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "IntegrateFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "desired_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "min_scale",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "actual_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "IsList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "IslandVoronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "LightNode": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "color",
+                    ""
+                ],
+                [
+                    "float",
+                    "intensity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "islight",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "invertdir",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Disk Plane",
+                    "Shape",
+                    "Plane"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "LineAddVert": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vert",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "LineCarve": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "insertU",
+                    ""
+                ],
+                [
+                    "bool",
+                    "cut",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "cut insert to end",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "LineResample": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "segments",
+                    "3"
+                ],
+                [
+                    "",
+                    "PrimSampler",
+                    ""
+                ],
+                [
+                    "string",
+                    "SampleBy",
+                    "t"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ListGetItem": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ListLength": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "length",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "LiveMeshNode": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "string",
+                    "vertSrc",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prims",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "LoadSampleModel": {
+            "inputs": [
+                [
+                    "enum cube monkey sphere humannose Pig_Head temple star",
+                    "name",
+                    "cube"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "decodeUVs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "LoadStringPrim": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "Zello World!"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make1DLinePrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "n",
+                    "2"
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum X Y Z",
+                    "Direction",
+                    "X"
+                ],
+                [
+                    "bool",
+                    "hasLines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make2DGridPrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "2"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "sizeX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeY",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum XZ XY YZ",
+                    "Direction",
+                    "XZ"
+                ],
+                [
+                    "bool",
+                    "hasFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make3DGridPointsInAABB": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "4"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "int",
+                    "nz",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isStaggered",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make3DGridPrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "2"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "int",
+                    "nz",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "sizeX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeZ",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeAxis": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisZ",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum off X Y Z",
+                    "normalize",
+                    "off"
+                ]
+            ],
+            "outputs": [
+                [
+                    "AxisObject",
+                    "math",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakeBoxPrimitive": {
+            "inputs": [
+                [
+                    "float",
+                    "size_x",
+                    ""
+                ],
+                [
+                    "float",
+                    "size_y",
+                    ""
+                ],
+                [
+                    "float",
+                    "size_z",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "use_quads",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeCamera": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "near",
+                    ""
+                ],
+                [
+                    "float",
+                    "far",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "CameraObject",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeCompressibleFlow": {
+            "inputs": [
+                [
+                    "",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "dx",
+                    ""
+                ],
+                [
+                    "",
+                    "q_amb",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "CompressibleFlow",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MakeCubePrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "spacing",
+                    ""
+                ],
+                [
+                    "",
+                    "nx",
+                    ""
+                ],
+                [
+                    "",
+                    "ny",
+                    ""
+                ],
+                [
+                    "",
+                    "nz",
+                    ""
+                ],
+                [
+                    "",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MakeCurve": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "MakeCurvemap": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "input_max",
+                    ""
+                ],
+                [
+                    "float",
+                    "input_min",
+                    ""
+                ],
+                [
+                    "float",
+                    "output_max",
+                    ""
+                ],
+                [
+                    "float",
+                    "output_min",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MakeDict": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "MakeDummy": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dummy",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "MakeGCTest": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "value",
+                    "42"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "MakeHeatmap": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "nres",
+                    "1024"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "MakeInstancing": {
+            "inputs": [
+                [
+                    "int",
+                    "amount",
+                    "1"
+                ],
+                [
+                    "list",
+                    "modelMatrices",
+                    ""
+                ],
+                [
+                    "float",
+                    "deltaTime",
+                    ""
+                ],
+                [
+                    "list",
+                    "timeList",
+                    ""
+                ],
+                [
+                    "list",
+                    "framePrims",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "instancing",
+                    "inst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeJFNKSolver2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "JFNKSolverObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "MakeLight": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "lightDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "intensity",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shadowTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "lightHight",
+                    ""
+                ],
+                [
+                    "float",
+                    "shadowSoftness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "lightColor",
+                    ""
+                ],
+                [
+                    "float",
+                    "lightScale",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isEnabled",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LightObject",
+                    "light",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeList": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "MakeLocalSys": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "front",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "right",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "LocalSys",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakeMPMMehser": {
+            "inputs": [
+                [
+                    "",
+                    "pathPreFix",
+                    ""
+                ],
+                [
+                    "",
+                    "tet_path",
+                    ""
+                ],
+                [
+                    "",
+                    "smooth_iter",
+                    ""
+                ],
+                [
+                    "",
+                    "start",
+                    ""
+                ],
+                [
+                    "",
+                    "end",
+                    ""
+                ],
+                [
+                    "",
+                    "edge_stretch",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "MPMMehser",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "GPUMPM"
+            ]
+        },
+        "MakeMultilineString": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "multiline_string",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeNonlinearProblemObject2": {
+            "inputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "NonlinearProblemObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "MakeOrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakePointPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakePrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakePrimitiveFromList": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeReadPath": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeShaderUniform": {
+            "inputs": [
+                [
+                    "int",
+                    "size",
+                    "512"
+                ],
+                [
+                    "",
+                    "uniformDict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeSmallDict": {
+            "inputs": [
+                [
+                    "string",
+                    "key0",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj0",
+                    ""
+                ],
+                [
+                    "string",
+                    "key1",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "string",
+                    "key2",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "string",
+                    "key3",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj3",
+                    ""
+                ],
+                [
+                    "string",
+                    "key4",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj4",
+                    ""
+                ],
+                [
+                    "string",
+                    "key5",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj5",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "MakeSmallList": {
+            "inputs": [
+                [
+                    "",
+                    "obj0",
+                    ""
+                ],
+                [
+                    "",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "",
+                    "obj3",
+                    ""
+                ],
+                [
+                    "",
+                    "obj4",
+                    ""
+                ],
+                [
+                    "",
+                    "obj5",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doConcat",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "MakeString": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeTexture2D": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "enum REPEAT MIRRORED_REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrapS",
+                    "REPEAT"
+                ],
+                [
+                    "enum REPEAT MIRRORED_REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrapT",
+                    "REPEAT"
+                ],
+                [
+                    "enum NEAREST LINEAR NEAREST_MIPMAP_NEAREST LINEAR_MIPMAP_NEAREST NEAREST_MIPMAP_LINEAR LINEAR_MIPMAP_LINEAR",
+                    "minFilter",
+                    "LINEAR"
+                ],
+                [
+                    "enum NEAREST LINEAR NEAREST_MIPMAP_NEAREST LINEAR_MIPMAP_NEAREST NEAREST_MIPMAP_LINEAR LINEAR_MIPMAP_LINEAR",
+                    "magFilter",
+                    "LINEAR"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "texture",
+                    "tex",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeVDBGrid": {
+            "inputs": [
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    ""
+                ],
+                [
+                    "enum vertex Centered Staggered",
+                    "structure",
+                    "Centered"
+                ],
+                [
+                    "enum float float3 int int3 points",
+                    "type",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "MakeVelocityPressure": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MakeVisualAABBPrimitive": {
+            "inputs": [
+                [
+                    "float",
+                    "dx",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "boundMin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "boundMax",
+                    ""
+                ],
+                [
+                    "int",
+                    "OpenTop",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum points edges trifaces quadfaces",
+                    "type",
+                    "edges"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "MakeWritePath": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MarkMovingSolidCellsByVDB": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SDFVDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "SolidVelVDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MatTranspose": {
+            "inputs": [
+                [
+                    "",
+                    "mat",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transposeMat",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MelFilter": {
+            "inputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "15"
+                ],
+                [
+                    "float",
+                    "sampleFreq",
+                    ""
+                ],
+                [
+                    "float",
+                    "rangePerFilter",
+                    ""
+                ],
+                [
+                    "enum none index indexdivcount",
+                    "indexType",
+                    "index"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FilterBank",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "MeshCopy": {
+            "inputs": [
+                [
+                    "",
+                    "copyFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "copyTo",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshMix": {
+            "inputs": [
+                [
+                    "",
+                    "meshA",
+                    ""
+                ],
+                [
+                    "",
+                    "meshB",
+                    ""
+                ],
+                [
+                    "",
+                    "coef",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshToSDF": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vertex cell",
+                    "type",
+                    "vertex"
+                ],
+                [
+                    "float",
+                    "voxel_size",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MesherProcessFrame": {
+            "inputs": [
+                [
+                    "",
+                    "Mesher",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNumber",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FramePrimitive",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "GPUMPM"
+            ]
+        },
+        "MocDictAsInput": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict2"
+            ]
+        },
+        "MocDictAsOutput": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict2"
+            ]
+        },
+        "MockList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list2"
+            ]
+        },
+        "MomentumTransfer2DFiniteDifference": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "string",
+                    "channel",
+                    "d"
+                ],
+                [
+                    "string",
+                    "add_channel",
+                    "d"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum FIVE_STENCIL NINE_STENCIL",
+                    "OpType",
+                    "FIVE_STENCIL"
+                ],
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "MoveAssign": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "MoveClone": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "newObject",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "MoveDelete": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "Noise_gabor_2d": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "a_",
+                    ""
+                ],
+                [
+                    "float",
+                    "frequency",
+                    ""
+                ],
+                [
+                    "float",
+                    "Orientation",
+                    ""
+                ],
+                [
+                    "int",
+                    "impulses_per_kernel",
+                    "64"
+                ],
+                [
+                    "bool",
+                    "isotropic",
+                    "0"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "NumRandom": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "dir",
+                    ""
+                ],
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum scalar01 scalar11 cube01 cube11 plane01 plane11 disk cylinder ball semiball sphere semisphere",
+                    "randType",
+                    "scalar01"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomFloat": {
+            "inputs": [
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "float",
+                    "valmin",
+                    ""
+                ],
+                [
+                    "float",
+                    "valmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomInt": {
+            "inputs": [
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "int",
+                    "valmin",
+                    "0"
+                ],
+                [
+                    "int",
+                    "valmax",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomSeedCombine": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ],
+                [
+                    "int",
+                    "w",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "seed",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericCounter": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "count",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericEval": {
+            "inputs": [
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "enum float vec3f int string",
+                    "resType",
+                    "float"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericFloat": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericInt": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "value",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec2i",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec3": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3i",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec4": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec4f",
+                    "vec4",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericInterpolation": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "src",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "srcMin",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "srcMax",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dstMin",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dstMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isClamped",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericOperator": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "lhs",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "rhs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum add sub mul div mod and or xor shr shl cmpge cmple cmpgt cmplt cmpne cmpeq land lor pos neg inv not atan2 pow max min fmod dot cross distance length normalize abs sqrt sin cos tan asin acos atan exp log floor ceil toint tofloat anytrue alltrue copy copyr",
+                    "op_type",
+                    "add"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericRandom": {
+            "inputs": [
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "dim",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "symmetric",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "NumericRandomInt": {
+            "inputs": [
+                [
+                    "int",
+                    "min",
+                    "0"
+                ],
+                [
+                    "int",
+                    "max",
+                    "65536"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "NumericRangeList": {
+            "inputs": [
+                [
+                    "int",
+                    "start",
+                    "0"
+                ],
+                [
+                    "int",
+                    "end",
+                    "1"
+                ],
+                [
+                    "int",
+                    "skip",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "NumericVec2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec2f",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericVec3": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericVec4": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec4f",
+                    "vec4",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericWrangle": {
+            "inputs": [
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject:NumericObject",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "OSDPrimSubdiv": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "levels",
+                    "2"
+                ],
+                [
+                    "string",
+                    "edgeCreaseAttr",
+                    ""
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "asQuadFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "hasLoopUVs",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "delayTillIpc",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ObjTimeShift": {
+            "inputs": [
+                [
+                    "IObject",
+                    "obj",
+                    ""
+                ],
+                [
+                    "int",
+                    "offset",
+                    "1"
+                ],
+                [
+                    "ListObject",
+                    "customList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IObject",
+                    "obj",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "prevObj",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "OrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PackNumericIntVec2": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec2i",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PackNumericVec": {
+            "inputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum float vec2f vec3f vec4f",
+                    "type",
+                    "vec3f"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PackNumericVecInt": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ],
+                [
+                    "int",
+                    "w",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum int vec2i vec3i vec4i",
+                    "type",
+                    "vec3i"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "veci",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "ParamFileParser": {
+            "inputs": [
+                [
+                    "",
+                    "formatList",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "configFilePath",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ParamFormat": {
+            "inputs": [
+                [
+                    "string",
+                    "name",
+                    ""
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i string",
+                    "type",
+                    "string"
+                ],
+                [
+                    "string",
+                    "defaultValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "format",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ParameterizeLine": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ParticleAsVoxels": {
+            "inputs": [
+                [
+                    "VDBGrid",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "Attr",
+                    ""
+                ],
+                [
+                    "",
+                    "particles",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "ParticleParticleWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticleToLevelSet": {
+            "inputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "float",
+                    "Radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "SurfaceSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ParticlesBuildBvh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "radiusMin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesBuildHashGrid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "numeric:float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "numeric:float",
+                    "radiusMin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "hashgrid",
+                    "hashGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesMaskedWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "string",
+                    "maskAttr",
+                    "mask"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborBvhWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "bool",
+                    "is_box",
+                    "1"
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborBvhWrangleSorted": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "bool",
+                    "is_box",
+                    "1"
+                ],
+                [
+                    "int",
+                    "limit",
+                    "-1"
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "HashGrid",
+                    "hashGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ParticlesTwoWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "PixarOrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PlaneProjectPrimitive2DAABB": {
+            "inputs": [
+                [
+                    "",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "normal",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "boundMin2D",
+                    ""
+                ],
+                [
+                    "",
+                    "boundMax2D",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PolyDuplicate": {
+            "inputs": [
+                [
+                    "",
+                    "Mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Meshes",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PortalIn": {
+            "inputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "RenameMe!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "PortalOut": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "RenameMe!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "PrimAttrInterp": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    ""
+                ],
+                [
+                    "float",
+                    "factor",
+                    ""
+                ],
+                [
+                    "string",
+                    "facAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBarycentricInterp": {
+            "inputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "MeshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "triIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "weightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBend": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "midPoint",
+                    ""
+                ],
+                [
+                    "float",
+                    "biasDir",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBoundingBox": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "extraBound",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "center",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "diameter",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCalcCentroid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum Volume Area Vertex BoundBox",
+                    "method",
+                    "Volume"
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "centroid",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCheckTagInRange": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "index"
+                ],
+                [
+                    "int",
+                    "beg",
+                    "0"
+                ],
+                [
+                    "int",
+                    "end",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "endExcluded",
+                    "0"
+                ],
+                [
+                    "int",
+                    "modularBy",
+                    "0"
+                ],
+                [
+                    "int",
+                    "trueVal",
+                    "1"
+                ],
+                [
+                    "int",
+                    "falseVal",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimColorByTag": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "clrAttr",
+                    "clr"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "PrimConnectBridge": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "edgeIndAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimConnectSkin": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isCloseRing",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimConnectTape": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "enum quads lines none",
+                    "faceType",
+                    "quads"
+                ],
+                [
+                    "bool",
+                    "isCloseRing",
+                    "0"
+                ],
+                [
+                    "string",
+                    "edgeMaskAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCopyFloatAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "sourceName",
+                    "s"
+                ],
+                [
+                    "string",
+                    "targetName",
+                    "t"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDecodeUVs": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimDualMesh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "polygonate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "keepBounds",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDuplicate": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "tanAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "radAttr",
+                    ""
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "copyParsAttr",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "copyMeshAttr",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDuplicateConnLines": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "tanAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "radAttr",
+                    ""
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "copyParsAttr",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "copyMeshAttr",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimEdgeBound": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "killDeadVerts",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimExtrude": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "maskAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "extrude",
+                    ""
+                ],
+                [
+                    "float",
+                    "inset",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "string",
+                    "sourceMaskAttrO",
+                    ""
+                ],
+                [
+                    "bool",
+                    "delOldFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "autoFindEdges",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "averagedExtrude",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "flipOldFaces",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFacesAttrToVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum lines tris quads polys",
+                    "faceType",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "faceAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "vertAttr",
+                    "tmp"
+                ],
+                [
+                    "float",
+                    "deflVal",
+                    ""
+                ],
+                [
+                    "enum sum average min max",
+                    "method",
+                    "average"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFacesCenterAsVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum faces lines",
+                    "faceType",
+                    "faces"
+                ],
+                [
+                    "bool",
+                    "copyFaceAttrs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFillAttr": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "rad"
+                ],
+                [
+                    "enum float vec3f int",
+                    "type",
+                    "float"
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFillColor": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFilter": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "revampAttrO",
+                    ""
+                ],
+                [
+                    "int",
+                    "tagValue",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isInversed",
+                    "1"
+                ],
+                [
+                    "enum verts faces",
+                    "method",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFlattenTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFlipFaces": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFloatAttrToInt": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "tag"
+                ],
+                [
+                    "float",
+                    "divisor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimForceTrail": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "trailPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "forceAttr",
+                    "force"
+                ],
+                [
+                    "float",
+                    "attractForce",
+                    ""
+                ],
+                [
+                    "float",
+                    "driftForce",
+                    ""
+                ],
+                [
+                    "",
+                    "attractUDFCurve",
+                    ""
+                ],
+                [
+                    "",
+                    "driftCoordCurve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimGenerateONB": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    "nrm"
+                ],
+                [
+                    "string",
+                    "tanAttrOut",
+                    "tang"
+                ],
+                [
+                    "string",
+                    "bitanAttrOut",
+                    "bitang"
+                ],
+                [
+                    "bool",
+                    "writebackDir",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimGetAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "index"
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i",
+                    "type",
+                    "int"
+                ],
+                [
+                    "enum vert tri",
+                    "method",
+                    "tri"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimGetTrisSize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "TrisSize",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimIntAttrToFloat": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "tag"
+                ],
+                [
+                    "float",
+                    "divisor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimKillDeadVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimLineGenerateONB": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttrOut",
+                    "dir"
+                ],
+                [
+                    "string",
+                    "tanAttrOut",
+                    "tang"
+                ],
+                [
+                    "string",
+                    "bitanAttrOut",
+                    "bitang"
+                ],
+                [
+                    "bool",
+                    "lineSort",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimLoopUVsToVerts": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkClose": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "distance",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "weld"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkIndex": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "index"
+                ],
+                [
+                    "enum int float",
+                    "type",
+                    "int"
+                ],
+                [
+                    "int",
+                    "base",
+                    "0"
+                ],
+                [
+                    "int",
+                    "step",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkIsland": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkSameIf": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttrIn",
+                    "index"
+                ],
+                [
+                    "int",
+                    "tagValueIs",
+                    "0"
+                ],
+                [
+                    "string",
+                    "tagAttrOut",
+                    "weld"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkTrisIdx": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "idxName",
+                    "index"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimMatchUVLine": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "uvAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "uvAttr2",
+                    "tmp"
+                ],
+                [
+                    "bool",
+                    "copyOtherAttrs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMerge": {
+            "inputs": [
+                [
+                    "list",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimPerlinNoise": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "inAttr",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "outAttr",
+                    "tmp"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "detail",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "disortion",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "average",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "enum float vec3f",
+                    "outType",
+                    "float"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimPointTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "pointID",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimProject": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "limit",
+                    ""
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimQuadsLotSubdivision": {
+            "inputs": [
+                [
+                    "",
+                    "input_quads_model",
+                    ""
+                ],
+                [
+                    "int",
+                    "num",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "row_or_columns",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "random_rc",
+                    "0"
+                ],
+                [
+                    "int",
+                    "random_seed",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "rcrc",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "first_second_same",
+                    "1"
+                ],
+                [
+                    "int",
+                    "same_seed",
+                    "1"
+                ],
+                [
+                    "float",
+                    "min_offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "first_edge_minoffset",
+                    ""
+                ],
+                [
+                    "float",
+                    "first_edge_maxoffset",
+                    ""
+                ],
+                [
+                    "int",
+                    "first_seed",
+                    "1"
+                ],
+                [
+                    "float",
+                    "second_edge_minoffset",
+                    ""
+                ],
+                [
+                    "float",
+                    "second_edge_maxoffset",
+                    ""
+                ],
+                [
+                    "int",
+                    "second_seed",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "add_attr",
+                    "0"
+                ],
+                [
+                    "string",
+                    "tag_attr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimRandomize": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "seedAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum scalar01 scalar11 cube01 cube11 plane01 plane11 disk cylinder ball semiball sphere semisphere",
+                    "randType",
+                    "scalar01"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "sampledObject",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "uv"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "enum REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrap",
+                    "REPEAT"
+                ],
+                [
+                    "vec3f",
+                    "borderColor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample1D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "rho"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample2D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "string",
+                    "uvChannel",
+                    "uv"
+                ],
+                [
+                    "string",
+                    "targetChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "enum REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrap",
+                    "REPEAT"
+                ],
+                [
+                    "vec3f",
+                    "borderColor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample3D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimScale": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimScatter": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum tris lines",
+                    "type",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "denAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "float",
+                    "minRadius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "interpAttrs",
+                    "1"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSepTriangles": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "smoothNormal",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "keepTriFaces",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSetAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "value",
+                    "0"
+                ],
+                [
+                    "string",
+                    "name",
+                    "index"
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i",
+                    "type",
+                    "int"
+                ],
+                [
+                    "enum vert tri",
+                    "method",
+                    "tri"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimSimplifyTag": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSmooth": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSplit": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSprayParticles": {
+            "inputs": [
+                [
+                    "",
+                    "TrianglePrim",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSuperFormula": {
+            "inputs": [
+                [
+                    "int",
+                    "segments",
+                    "1000"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "a",
+                    ""
+                ],
+                [
+                    "float",
+                    "b",
+                    ""
+                ],
+                [
+                    "float",
+                    "m",
+                    ""
+                ],
+                [
+                    "float",
+                    "n1",
+                    ""
+                ],
+                [
+                    "float",
+                    "n2",
+                    ""
+                ],
+                [
+                    "float",
+                    "n3",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasLines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "close",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimToList": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads polys loops",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimToVDBPointDataGrid": {
+            "inputs": [
+                [
+                    "",
+                    "ParticleGeo",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbPoints",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "PrimTranslate": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimTriPoints": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "trisID",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimTwist": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimUnmerge": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "bool",
+                    "preSimplify",
+                    "0"
+                ],
+                [
+                    "enum verts faces",
+                    "method",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "list",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimUpdateFromList": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads polys loops",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimVertsAttrToFaces": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum lines tris quads polys",
+                    "faceType",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "vertAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "faceAttr",
+                    "tmp"
+                ],
+                [
+                    "enum sum average min max",
+                    "method",
+                    "average"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimWeld": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "weld"
+                ],
+                [
+                    "enum oneof average",
+                    "method",
+                    "oneof"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimWireframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveAddAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "fillValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "clr"
+                ],
+                [
+                    "string",
+                    "pybisgreat",
+                    "DEPRECATED! USE PrimFillAttr INSTEAD"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveAttrFit": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "refPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrNameSrc",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrNameDst",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "refAttrNameSrc",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "refAttrNameDst",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "enum X Y Z",
+                    "axisSrc",
+                    "X"
+                ],
+                [
+                    "enum X Y Z",
+                    "axisDst",
+                    "Y"
+                ],
+                [
+                    "enum X Y Z",
+                    "refAxisSrc",
+                    "X"
+                ],
+                [
+                    "enum X Y Z",
+                    "refAxisDst",
+                    "Y"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "autoMinMax",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "autoSort",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveAttrPicker": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum point line triangle",
+                    "mode",
+                    "point"
+                ],
+                [
+                    "string",
+                    "newAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "attrVal",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "selected",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveBent": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "midPoint",
+                    ""
+                ],
+                [
+                    "float",
+                    "biasDir",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "useOrigin",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveBinaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrB",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copyA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveBooleanOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "faceAttrA",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "faceAttrB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "calcAnyFrom",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix",
+                    "0"
+                ],
+                [
+                    "string",
+                    "faceAttrName",
+                    ""
+                ],
+                [
+                    "enum Union Intersect Minus RevMinus XOR Resolve",
+                    "op_type",
+                    "Union"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primC",
+                    ""
+                ],
+                [
+                    "bool",
+                    "anyFromA",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "anyFromB",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveBoundingBox": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "exWidth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveCalcCentroid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Volume Area Vertex",
+                    "method",
+                    "Volume"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "centroid",
+                    ""
+                ],
+                [
+                    "float",
+                    "totalArea",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveCalcNormal": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "bool",
+                    "flip",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveCalcVelocity": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveClearConnect": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum edges faces tris quads polys points all",
+                    "type",
+                    "all"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveClip": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "distance",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "reverse",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveColorByHeatmap": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "float",
+                    "min",
+                    ""
+                ],
+                [
+                    "float",
+                    "max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "rho"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveConvexDecomposition": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveConvexDecompositionV": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveCurvemap": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "int",
+                    "sourceX",
+                    "0"
+                ],
+                [
+                    "int",
+                    "sourceY",
+                    "1"
+                ],
+                [
+                    "int",
+                    "sourceZ",
+                    "2"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveDelAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "nrm"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveDuplicate": {
+            "inputs": [
+                [
+                    "",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "float",
+                    "uniScale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "attrFromMesh",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "attrFromParticles",
+                    "1"
+                ],
+                [
+                    "string",
+                    "scaleByAttr",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFaceToEdges": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "clearFaces",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFarSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveFillAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3 none",
+                    "attrType",
+                    "none"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFilterByAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum cmpgt cmplt cmpge cmple cmpeq cmpne",
+                    "acceptIf",
+                    "cmpgt"
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "rad"
+                ],
+                [
+                    "bool",
+                    "mockTopos",
+                    "1"
+                ],
+                [
+                    "enum any all",
+                    "vecSelType",
+                    "all"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveFlipPoly": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveGetAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveGetFaceCount": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveGetSize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveHalfBinaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "valueB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copyA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveInterpSubframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "portion",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineDistance": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "resAttr",
+                    "len"
+                ],
+                [
+                    "int",
+                    "start",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSimpleLink": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSolidify": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "4"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "string",
+                    "radiusAttr",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isTri",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "sealEnd",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "closeRing",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "lineSort",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSort": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "reversed",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveListBoolOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primListB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    ""
+                ],
+                [
+                    "bool",
+                    "assignAttrs",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "calcAnyFrom",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix",
+                    "1"
+                ],
+                [
+                    "string",
+                    "faceAttrName",
+                    ""
+                ],
+                [
+                    "bool",
+                    "noNullMesh",
+                    "1"
+                ],
+                [
+                    "enum Union Intersect Minus RevMinus XOR Resolve",
+                    "op_type",
+                    "Union"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "lutList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveMerge": {
+            "inputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveMeshingFix": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primFixed",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveMix": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "coef",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrB",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveNearSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitivePerlinNoiseAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "freq",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "noise"
+            ]
+        },
+        "PrimitivePolygonate": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "with_uv",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitivePrintAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveRandomAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "min",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveRandomizeAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float3"
+                ],
+                [
+                    "float",
+                    "max",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxY",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxZ",
+                    ""
+                ],
+                [
+                    "float",
+                    "min",
+                    ""
+                ],
+                [
+                    "float",
+                    "minY",
+                    ""
+                ],
+                [
+                    "float",
+                    "minZ",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveReduction": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "enum avg max min absmax",
+                    "op",
+                    "avg"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveResize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveScale": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axis",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveScatter": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "npoints",
+                    "100"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum tris lines",
+                    "type",
+                    "tris"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSetAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimplePoints": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleQuads": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSplitEdges": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToBulletMesh": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveToMesh": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToParticles": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToSDF": {
+            "inputs": [
+                [
+                    "",
+                    "PrimitiveMesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vertex cell",
+                    "type",
+                    "vertex"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "PrimitiveTraceTrail": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "trailPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTransform": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum world bboxCenter",
+                    "pivot",
+                    "world"
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "eulerXYZ",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shear",
+                    ""
+                ],
+                [
+                    "",
+                    "Matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "preTransform",
+                    ""
+                ],
+                [
+                    "",
+                    "local",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTriangulate": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "from_poly",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "from_quads",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "has_lines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "with_uv",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTwist": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveUnaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copy"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveVoronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "int",
+                    "numParticles",
+                    "64"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    "use VoronoiFracture instead!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveWireframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrintMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello-stdout"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "PrintMessageStdErr": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello-stderr"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "PrintNumeric": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "hint",
+                    "PrintNumeric"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PrintPrimInfo": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "printInfo",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrintString": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ProceduralSky": {
+            "inputs": [
+                [
+                    "vec2f",
+                    "sunLightDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "sunLightSoftness",
+                    ""
+                ],
+                [
+                    "float",
+                    "sunLightIntensity",
+                    ""
+                ],
+                [
+                    "float",
+                    "colorTemperatureMix",
+                    ""
+                ],
+                [
+                    "float",
+                    "colorTemperature",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "windDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "timeStart",
+                    ""
+                ],
+                [
+                    "float",
+                    "timeSpeed",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "ProceduralSky",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ProjectAndNormalize": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "enum XY YX YZ ZY ZX XZ",
+                    "plane",
+                    "XY"
+                ],
+                [
+                    "float",
+                    "directionScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "lengthScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "heightScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "heightOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "length",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "float",
+                    "phase",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "QuatRotBetweenVectors": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "start",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "dest",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "QueryNearestPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "string",
+                    "idTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "distTag",
+                    "bvh_dist"
+                ],
+                [
+                    "string",
+                    "closestPointTag",
+                    "cp"
+                ],
+                [
+                    "string",
+                    "weightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "primid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "bvh_primid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dist",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "bvh_prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "segment",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "RadtoDegree": {
+            "inputs": [
+                [
+                    "float",
+                    "radian",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "degree",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "RandomParticles": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "Prange",
+                    ""
+                ],
+                [
+                    "float",
+                    "Vrange",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "1 0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadAudioFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "ReadCustomVAT": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadFBXPrim": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "bool",
+                    "generate",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "invOpacity",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "primitive",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "printTree",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "0"
+                ],
+                [
+                    "enum ENABLE DISABLE",
+                    "udim",
+                    "DISABLE"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "prims",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "datas",
+                    ""
+                ],
+                [
+                    "",
+                    "mats",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ReadImageFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadLightFromFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "posList",
+                    ""
+                ],
+                [
+                    "",
+                    "rotList",
+                    ""
+                ],
+                [
+                    "",
+                    "sclList",
+                    ""
+                ],
+                [
+                    "",
+                    "colList",
+                    ""
+                ],
+                [
+                    "",
+                    "intList",
+                    ""
+                ],
+                [
+                    "",
+                    "expList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ReadMp3File": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjPrim": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadObjPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjPrimitiveDict": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadParticles": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadPlyPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadVATFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadVDB": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum float float3 int int3 points",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ReadVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadWavFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "RefitPrimitiveBvh": {
+            "inputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ResampleVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "resampleTo",
+                    ""
+                ],
+                [
+                    "",
+                    "resampleFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "resampleTo",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ResizeList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "int",
+                    "newSize",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "RobotGetJointName": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotGetLinkName": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotLoadURDF": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "float",
+                    "globalScaling",
+                    ""
+                ],
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "fixedBase",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "visualMap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotSetJointPoses": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "qDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "Route": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "SDFAdvect": {
+            "inputs": [
+                [
+                    "",
+                    "InoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "VecField",
+                    ""
+                ],
+                [
+                    "float",
+                    "TimeStep",
+                    ""
+                ],
+                [
+                    "enum Order_1 Order_2 Order_3 Order_5_WENO Order_5_HJ_WENO",
+                    "SpatialScheme",
+                    "Order_5_HJ_WENO"
+                ],
+                [
+                    "enum Explicit_Euler Order_2_Runge_Kuta Order_3_Runge_Kuta",
+                    "TemporalScheme",
+                    "Order_2_Runge_Kuta"
+                ],
+                [
+                    "int",
+                    "RenormalizeStep",
+                    "3"
+                ],
+                [
+                    "enum Order_1 Order_2 Order_3 Order_5_WENO Order_5_HJ_WENO",
+                    "TrackerSpatialScheme",
+                    "Order_5_HJ_WENO"
+                ],
+                [
+                    "enum Explicit_Euler Order_2_Runge_Kuta Order_3_Runge_Kuta",
+                    "TrackerTemporalScheme",
+                    "Explicit_Euler"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "InoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFScatterPoints": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToFog": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "bool",
+                    "inplace",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToPoly": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "Mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SDFToPrim": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ],
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SampleVDBToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "sampleBy",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "primAttr",
+                    "sdf"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Clamp Periodic",
+                    "SampleType",
+                    "Clamp"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ScalarFieldAnalyzer": {
+            "inputs": [
+                [
+                    "",
+                    "InVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Gradient Curvature Laplacian ClosestPoint",
+                    "Operator",
+                    "Gradient"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "OutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SetFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "SetInstancing": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "instancing",
+                    "inst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "SetMaterial": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "material",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SetMatrix": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "SetRandomSeed": {
+            "inputs": [
+                [
+                    "",
+                    "routeIn",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "routeOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SetUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "SetVDBGridName": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "density"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SetVDBPointDataGrid": {
+            "inputs": [
+                [
+                    "",
+                    "ParticleGeo",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "dx",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ShaderBinaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "float",
+                    "in2",
+                    ""
+                ],
+                [
+                    "enum add sub mul div mod pow atan2 min max dot cross distance",
+                    "op",
+                    "add"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderBlendMode": {
+            "inputs": [
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "blend",
+                    ""
+                ],
+                [
+                    "float",
+                    "opacity",
+                    ""
+                ],
+                [
+                    "enum add average colorBurn colorDodge darken difference exclusion glow hardLight hardMix lighten linearBurn linearDodge linearLight multiply negation normal overlay phoenix pinLight reflect screen softLight subtract vividLight",
+                    "mode",
+                    "normal"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderCihouUnrealEngine": {
+            "inputs": [
+                [
+                    "MaterialObject",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "code",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderCustomFunc": {
+            "inputs": [
+                [
+                    "string",
+                    "args",
+                    "vec3 arg1, vec3 arg2"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "rettype",
+                    "vec3"
+                ],
+                [
+                    "string",
+                    "code",
+                    "return arg1 + arg2;"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ShaderCustomFuncObject",
+                    "func",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderExtractVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderFillVec": {
+            "inputs": [
+                [
+                    "float",
+                    "in",
+                    ""
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderFinalize": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "basecolor",
+                    ""
+                ],
+                [
+                    "float",
+                    "metallic",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "specular",
+                    ""
+                ],
+                [
+                    "float",
+                    "subsurface",
+                    ""
+                ],
+                [
+                    "float",
+                    "thickness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sssParam",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sssColor",
+                    ""
+                ],
+                [
+                    "float",
+                    "foliage",
+                    ""
+                ],
+                [
+                    "float",
+                    "skin",
+                    ""
+                ],
+                [
+                    "float",
+                    "curvature",
+                    ""
+                ],
+                [
+                    "float",
+                    "specularTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "anisotropic",
+                    ""
+                ],
+                [
+                    "float",
+                    "anisoRotation",
+                    ""
+                ],
+                [
+                    "float",
+                    "sheen",
+                    ""
+                ],
+                [
+                    "float",
+                    "sheenTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "clearcoat",
+                    ""
+                ],
+                [
+                    "float",
+                    "clearcoatGloss",
+                    ""
+                ],
+                [
+                    "float",
+                    "specTrans",
+                    ""
+                ],
+                [
+                    "float",
+                    "ior",
+                    ""
+                ],
+                [
+                    "float",
+                    "flatness",
+                    ""
+                ],
+                [
+                    "float",
+                    "scatterDistance",
+                    ""
+                ],
+                [
+                    "float",
+                    "scatterStep",
+                    ""
+                ],
+                [
+                    "float",
+                    "thin",
+                    ""
+                ],
+                [
+                    "float",
+                    "doubleSide",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "float",
+                    "displacement",
+                    ""
+                ],
+                [
+                    "float",
+                    "smoothness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "emission",
+                    ""
+                ],
+                [
+                    "float",
+                    "exposure",
+                    ""
+                ],
+                [
+                    "float",
+                    "ao",
+                    ""
+                ],
+                [
+                    "float",
+                    "toon",
+                    ""
+                ],
+                [
+                    "float",
+                    "stroke",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shape",
+                    ""
+                ],
+                [
+                    "float",
+                    "style",
+                    ""
+                ],
+                [
+                    "float",
+                    "strokeNoise",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shad",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "strokeTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "opacity",
+                    ""
+                ],
+                [
+                    "float",
+                    "reflection",
+                    ""
+                ],
+                [
+                    "float",
+                    "reflectID",
+                    ""
+                ],
+                [
+                    "float",
+                    "isCamera",
+                    ""
+                ],
+                [
+                    "float",
+                    "isVoxelDomain",
+                    ""
+                ],
+                [
+                    "string",
+                    "commonCode",
+                    ""
+                ],
+                [
+                    "string",
+                    "extensionsCode",
+                    ""
+                ],
+                [
+                    "string",
+                    "mtlid",
+                    "Mat1"
+                ],
+                [
+                    "list",
+                    "tex2dList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum GLSL HLSL",
+                    "backend",
+                    "GLSL"
+                ]
+            ],
+            "outputs": [
+                [
+                    "MaterialObject",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderInputAttr": {
+            "inputs": [
+                [
+                    "enum pos clr nrm uv tang bitang NoL instPos instNrm instUv instClr instTang",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderInvokeFunc": {
+            "inputs": [
+                [
+                    "ShaderCustomFuncObject",
+                    "func",
+                    ""
+                ],
+                [
+                    "list",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderLinearFit": {
+            "inputs": [
+                [
+                    "float",
+                    "in",
+                    ""
+                ],
+                [
+                    "float",
+                    "inMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "inMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "outMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "outMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "clamped",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderMakeVec": {
+            "inputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderPackVec": {
+            "inputs": [
+                [
+                    "shader",
+                    "x",
+                    ""
+                ],
+                [
+                    "shader",
+                    "y",
+                    ""
+                ],
+                [
+                    "shader",
+                    "z",
+                    ""
+                ],
+                [
+                    "shader",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderReduceVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "in",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum average sum",
+                    "op",
+                    "average"
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderTernaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "float",
+                    "in2",
+                    ""
+                ],
+                [
+                    "float",
+                    "in3",
+                    ""
+                ],
+                [
+                    "enum mix clamp smoothstep add3",
+                    "op",
+                    "mix"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderTexture2D": {
+            "inputs": [
+                [
+                    "int",
+                    "texId",
+                    "0"
+                ],
+                [
+                    "vec2f",
+                    "coord",
+                    ""
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderUnaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "enum copy neg abs sqrt inversesqrt exp log sin cos tan asin acos atan degrees radians sinh cosh tanh asinh acosh atanh round roundEven floor ceil trunc sign step length normalize",
+                    "op",
+                    "sqrt"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderUniformAttr": {
+            "inputs": [
+                [
+                    "int",
+                    "idx",
+                    "0"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "SimplifyVoroNeighborList": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ListObject",
+                    "newNeighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "SolveNonlinearProblem2": {
+            "inputs": [
+                [
+                    "",
+                    "JFNKSolverObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "NonlinearProblemObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "SpdlogErrorMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "error from spdlog!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "SpdlogInfoMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello from spdlog!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "StringEqual": {
+            "inputs": [
+                [
+                    "string",
+                    "lhs",
+                    ""
+                ],
+                [
+                    "string",
+                    "rhs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "isEqual",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "StringEval": {
+            "inputs": [
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "StringFormat": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringFormatNumStr": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "{}"
+                ],
+                [
+                    "",
+                    "num_str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "StringFormatNumber": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "{}"
+                ],
+                [
+                    "",
+                    "number",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringToMesh": {
+            "inputs": [
+                [
+                    "",
+                    "string",
+                    ""
+                ],
+                [
+                    "",
+                    "AZmesh",
+                    ""
+                ],
+                [
+                    "",
+                    "spacing",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "StringMeshList",
+                    ""
+                ],
+                [
+                    "",
+                    "SpacingList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringToNumber": {
+            "inputs": [
+                [
+                    "enum float int",
+                    "type",
+                    "all"
+                ],
+                [
+                    "string",
+                    "str",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "num_str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "SubCategory": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "subgraph"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubInput": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "defl",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "input1"
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasValue",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubLine": {
+            "inputs": [
+                [
+                    "",
+                    "line",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum cmpgt cmplt cmpge cmple cmpeq cmpne",
+                    "acceptIf",
+                    "cmpgt"
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "rad"
+                ],
+                [
+                    "enum any all",
+                    "vecSelType",
+                    "all"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SubOutput": {
+            "inputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "defl",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "output1"
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubstepDt": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "float",
+                    "desired_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "actual_dt",
+                    ""
+                ],
+                [
+                    "float",
+                    "portion",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "SyncPrimitiveAttributes": {
+            "inputs": [
+                [
+                    "",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "TestRayBox": {
+            "inputs": [
+                [
+                    "",
+                    "ray_origin",
+                    ""
+                ],
+                [
+                    "",
+                    "ray_dir",
+                    ""
+                ],
+                [
+                    "",
+                    "box_min",
+                    ""
+                ],
+                [
+                    "",
+                    "box_max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "predicate",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ToView": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isStatic",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "viewid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "TraceOneStep": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "steps",
+                    ""
+                ],
+                [
+                    "",
+                    "maxlength",
+                    ""
+                ],
+                [
+                    "",
+                    "vecField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "TracePositionOneStep": {
+            "inputs": [
+                [
+                    "",
+                    "primData",
+                    ""
+                ],
+                [
+                    "",
+                    "primStart",
+                    ""
+                ],
+                [
+                    "string",
+                    "lineTag",
+                    "lineID"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primVis",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "TransformMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "translate",
+                    ""
+                ],
+                [
+                    "",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "TransformPrimitive": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "eulerXYZ",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shear",
+                    ""
+                ],
+                [
+                    "",
+                    "Matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "preTransform",
+                    ""
+                ],
+                [
+                    "",
+                    "local",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "TriggerAbortSignal": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerDivideZero": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerException": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "exception occurred!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerExitProcess": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "status",
+                    "-1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerSegFault": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerViewportFault": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "UVProjectFromPlane": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "refPlane",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "UnpackNumericVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "X",
+                    ""
+                ],
+                [
+                    "float",
+                    "Y",
+                    ""
+                ],
+                [
+                    "float",
+                    "Z",
+                    ""
+                ],
+                [
+                    "float",
+                    "W",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "UpdateCurveControlPoint": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "optional float",
+                    "point_x",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "point_y",
+                    ""
+                ],
+                [
+                    "optional vec2f",
+                    "left_handler",
+                    ""
+                ],
+                [
+                    "optional vec2f",
+                    "right_handler",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "UpdateCurveCycleType": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "enum CLAMP CYCLE MIRROR",
+                    "type",
+                    "CLAMP"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "UpdateCurveXYRange": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "optional float",
+                    "x_from",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "x_to",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "y_from",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "y_to",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "VDBAddPerlinNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "VDBAddTurbulentNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBChangeBackground": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBCreateLevelsetSphere": {
+            "inputs": [
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "center",
+                    ""
+                ],
+                [
+                    "float",
+                    "half_width",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBDeactivate": {
+            "inputs": [
+                [
+                    "",
+                    "Field",
+                    ""
+                ],
+                [
+                    "",
+                    "Mask",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBDilateTopo": {
+            "inputs": [
+                [
+                    "",
+                    "inField",
+                    ""
+                ],
+                [
+                    "int",
+                    "layers",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBErodeSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "depth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBExplosiveTurbulentNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "FBM_EvalPersist",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_Lacunarity",
+                    ""
+                ],
+                [
+                    "int",
+                    "FBM_Octaves",
+                    "5"
+                ],
+                [
+                    "float",
+                    "FBM_Persistence",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpPersist",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpPrimary",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpSecond",
+                    ""
+                ],
+                [
+                    "float",
+                    "Speed",
+                    ""
+                ],
+                [
+                    "float",
+                    "UVScale",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBFillActiveVoxels": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "fillValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBGetBackground": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBInvertSDF": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBLeafAsParticles": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primPars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VDBPerlinNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale3d",
+                    ""
+                ],
+                [
+                    "float",
+                    "detail",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "disortion",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "average",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPointScatter": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "4"
+                ],
+                [
+                    "float",
+                    "spread",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum Fog SDF",
+                    "gridtype",
+                    "Fog"
+                ],
+                [
+                    "enum PerVoxel Total",
+                    "counttype",
+                    "PerVoxel"
+                ],
+                [
+                    "enum Uniform NonUniform",
+                    "method",
+                    "Uniform"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPointsToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPruneFootprint": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBRenormalizeSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "dilateIters",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "4"
+                ],
+                [
+                    "enum 1oUpwind",
+                    "method",
+                    "1oUpwind"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBSmooth": {
+            "inputs": [
+                [
+                    "",
+                    "inoutVDB",
+                    ""
+                ],
+                [
+                    "enum Mean Gaussian Median",
+                    "type",
+                    "Gaussian"
+                ],
+                [
+                    "int",
+                    "width",
+                    "1"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBSmoothSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    "Use VDBSmooth Instead"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "1"
+                ],
+                [
+                    "int",
+                    "width",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "VDBTopoCopy": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "topo",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBTouchAABBRegion": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBVoxelAsParticles": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "valToAttr",
+                    "sdf"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "asStaggers",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "hasInactive",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primPars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VDBWrangle": {
+            "inputs": [
+                [
+                    "VDBGrid",
+                    "grid",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "enum true false",
+                    "ModifyActive",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "ChangeBackground",
+                    "false"
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "VDBGrid",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "VectorFieldAnalyzer": {
+            "inputs": [
+                [
+                    "",
+                    "InVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Divergence Curl Magnitude Normalize",
+                    "Operator",
+                    "Divergence"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "OutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VisPrimAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "precision",
+                    "3"
+                ],
+                [
+                    "bool",
+                    "includeSelf",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "dotDecoration",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VisPrimAttrValue_Modify": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "precision",
+                    "3"
+                ],
+                [
+                    "bool",
+                    "includeSelf",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "dotDecoration",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "VisVec3Attribute": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "vel"
+                ],
+                [
+                    "bool",
+                    "normalize",
+                    "1"
+                ],
+                [
+                    "float",
+                    "lengthScale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "color",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primVis",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VisualUVObj": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "VolumeAdvect": {
+            "inputs": [
+                [
+                    "",
+                    "InField",
+                    ""
+                ],
+                [
+                    "",
+                    "VecField",
+                    ""
+                ],
+                [
+                    "float",
+                    "TimeStep",
+                    ""
+                ],
+                [
+                    "int",
+                    "SubSteps",
+                    "1"
+                ],
+                [
+                    "enum SemiLagrangian  MidPoint RK3 RK4 MacCormack BFECC",
+                    "Integrator",
+                    "BFECC"
+                ],
+                [
+                    "enum None Clamp Revert",
+                    "Limiter",
+                    "Revert"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "extend",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VoronoiFracture": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doMeshFix",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix2",
+                    "1"
+                ],
+                [
+                    "int",
+                    "numRandPoints",
+                    "256"
+                ],
+                [
+                    "bool",
+                    "periodicX",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicY",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicZ",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "WBPrimBend": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "Limit Deformation",
+                    "1"
+                ],
+                [
+                    "int",
+                    "Symmetric Deformation",
+                    "0"
+                ],
+                [
+                    "float",
+                    "Bend Angle (degree)",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Up Vector",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Capture Origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Capture Direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "Capture Length",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WXL_PrimProject": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "limit",
+                    ""
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteCustomVAT": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "frameEnd",
+                    "100"
+                ],
+                [
+                    "int",
+                    "frameStart",
+                    "0"
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WriteObjPrim": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "polygonate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WriteParticles": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WritePlyPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WritePrimToCSV": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads loops polys",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteVDB": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "WriteVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ZipListAsDict": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "keys",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "values",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "erode_compute_erosion": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "debrisLayerName",
+                    "debris"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "10"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "cut_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxdepth",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_domainWarping_v1": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmH",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmFrequence",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmAmplitude",
+                    ""
+                ],
+                [
+                    "int",
+                    "fbmNumOctaves",
+                    "4"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_domainWarping_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmH",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmFrequence",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmAmplitude",
+                    ""
+                ],
+                [
+                    "int",
+                    "fbmNumOctaves",
+                    "4"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v1": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v3": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_analytic_simplex_2d": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "analyticNoise"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_perlin": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "vec3fAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_simplex": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_sparse_convolution": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "int",
+                    "pulsenum",
+                    "3"
+                ],
+                [
+                    "int",
+                    "griddist",
+                    "2"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_worley": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "celljitter",
+                    ""
+                ],
+                [
+                    "enum Euclidean Chebyshev Manhattan",
+                    "distType",
+                    "Euclidean"
+                ],
+                [
+                    "enum F1 F2-F1",
+                    "fType",
+                    "F1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_precipitation": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "waterLayerName",
+                    "water"
+                ],
+                [
+                    "float",
+                    "amount",
+                    ""
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_project": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "int",
+                    "hitFarthest",
+                    "1"
+                ],
+                [
+                    "float",
+                    "maxDist",
+                    ""
+                ],
+                [
+                    "int",
+                    "doJitter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "numSamples",
+                    "3"
+                ],
+                [
+                    "float",
+                    "jitterScale",
+                    ""
+                ],
+                [
+                    "int",
+                    "jitterCombine",
+                    "1"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "1"
+                ],
+                [
+                    "int",
+                    "combineMethod",
+                    "3"
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_rand_color": {
+            "inputs": [
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_rand_dir": {
+            "inputs": [
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_slump_b2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "materialLayerName",
+                    "debris"
+                ],
+                [
+                    "string",
+                    "stabilitymaskLayerName",
+                    "_stability"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "10"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "repose_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "float",
+                    "flow_rate",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_slump_b4": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "materialLayerName",
+                    "water"
+                ],
+                [
+                    "string",
+                    "sedimentLayerName",
+                    "sediment"
+                ],
+                [
+                    "string",
+                    "debrisLayerName",
+                    "debris"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_debris_depth",
+                    ""
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "max_erodability_iteration",
+                    "5"
+                ],
+                [
+                    "float",
+                    "initial_erodability_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "slope_contribution_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "bed_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "depositionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "sedimentcap",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_bank_bed_ratio",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "40"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_terrainHiMeLo": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "fbm"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v0": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "cut_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxdepth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "repose_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "float",
+                    "flow_rate",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v4": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "40"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_debris_depth",
+                    ""
+                ],
+                [
+                    "int",
+                    "max_erodability_iteration",
+                    "5"
+                ],
+                [
+                    "float",
+                    "initial_erodability_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "slope_contribution_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "bed_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "depositionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "sedimentcap",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_bank_bed_ratio",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_value2cond": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_voronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "featurePrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "voronoi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "makeCompressibleSim": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SimParam",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "str2num": {
+            "inputs": [
+                [
+                    "enum float int",
+                    "type",
+                    "int"
+                ],
+                [
+                    "string",
+                    "str",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "num",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "testPoly1": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "testPoly2": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        }
+    },
+    "version": "v2.5"
+}

--- a/misc/graphs/GaborNoise.zsg
+++ b/misc/graphs/GaborNoise.zsg
@@ -108,7 +108,7 @@
                     },
                     "uipos": [
                         -9148.0,
-                        -652.4000000000002
+                        -652.4000244140625
                     ],
                     "options": []
                 },
@@ -133,7 +133,7 @@
                         },
                         "ElementSize": {
                             "link": null,
-                            "default-value": 15,
+                            "default-value": 10,
                             "control": {
                                 "name": "Integer"
                             },
@@ -161,7 +161,7 @@
                         },
                         "Impulse per kernel": {
                             "link": null,
-                            "default-value": 512,
+                            "default-value": 256,
                             "control": {
                                 "name": "Integer"
                             },
@@ -215,7 +215,7 @@
                     },
                     "uipos": [
                         -8389.8671875,
-                        -666.4000000000002
+                        -666.4000244140625
                     ],
                     "options": [
                         "VIEW"
@@ -231,7 +231,7 @@
                                     "control": {
                                         "name": ""
                                     },
-                                    "uuid": 2816753741
+                                    "uuid": 3217460581
                                 },
                                 "prim": {
                                     "core-param": {
@@ -241,7 +241,7 @@
                                     "control": {
                                         "name": ""
                                     },
-                                    "uuid": 1183632032
+                                    "uuid": 3063924579
                                 },
                                 "ElementSize": {
                                     "core-param": {
@@ -251,7 +251,7 @@
                                     "control": {
                                         "name": "Integer"
                                     },
-                                    "uuid": 3568526265
+                                    "uuid": 169961723
                                 },
                                 "Scale": {
                                     "core-param": {
@@ -261,7 +261,7 @@
                                     "control": {
                                         "name": "Float Vector 3"
                                     },
-                                    "uuid": 2368355282
+                                    "uuid": 3603864136
                                 },
                                 "noiseseed": {
                                     "core-param": {
@@ -271,7 +271,7 @@
                                     "control": {
                                         "name": "Float"
                                     },
-                                    "uuid": 3866951673
+                                    "uuid": 2912862577
                                 },
                                 "isotropic": {
                                     "core-param": {
@@ -281,7 +281,7 @@
                                     "control": {
                                         "name": "Boolean"
                                     },
-                                    "uuid": 2038060998
+                                    "uuid": 1640643107
                                 },
                                 "Impulse per kernel": {
                                     "core-param": {
@@ -291,7 +291,7 @@
                                     "control": {
                                         "name": "Integer"
                                     },
-                                    "uuid": 1754837282
+                                    "uuid": 2564582590
                                 },
                                 "frequency": {
                                     "core-param": {
@@ -301,7 +301,7 @@
                                     "control": {
                                         "name": "Float"
                                     },
-                                    "uuid": 2530381277
+                                    "uuid": 1645915877
                                 },
                                 "Orientation": {
                                     "core-param": {
@@ -311,7 +311,7 @@
                                     "control": {
                                         "name": "Float"
                                     },
-                                    "uuid": 2417648977
+                                    "uuid": 1159077219
                                 },
                                 "a_": {
                                     "core-param": {
@@ -321,7 +321,7 @@
                                     "control": {
                                         "name": "Float"
                                     },
-                                    "uuid": 3161084629
+                                    "uuid": 804812172
                                 },
                                 "offset": {
                                     "core-param": {
@@ -331,7 +331,7 @@
                                     "control": {
                                         "name": "Integer"
                                     },
-                                    "uuid": 178333203
+                                    "uuid": 1834424689
                                 }
                             },
                             "Parameters": {},
@@ -340,13 +340,13 @@
                                     "control": {
                                         "name": ""
                                     },
-                                    "uuid": 3800585735
+                                    "uuid": 3444469224
                                 },
                                 "prim": {
                                     "control": {
                                         "name": ""
                                     },
-                                    "uuid": 541239170
+                                    "uuid": 3262266475
                                 }
                             }
                         }
@@ -1327,9 +1327,9 @@
                     "blackboard": {
                         "special": false,
                         "width": 500.0,
-                        "height": 510.0,
+                        "height": 520.0,
                         "title": "title",
-                        "content": "a 0.005-0.1  F 0.01-0.3  omega 0.0-M_PI"
+                        "content": "可以参考的范围\na 0.005-0.1  F 0.01-0.3  omega 0.0-M_PI"
                     }
                 },
                 "827f4939-Noise_gabor_2d": {
@@ -1422,8 +1422,8 @@
                         "DST": {}
                     },
                     "uipos": [
-                        -993.6000000000003,
-                        1059.2
+                        -993.5999755859375,
+                        1059.199951171875
                     ],
                     "options": []
                 }

--- a/misc/graphs/Sparse Convolution noise.zsg
+++ b/misc/graphs/Sparse Convolution noise.zsg
@@ -1,0 +1,29191 @@
+{
+    "graph": {
+        "main": {
+            "nodes": {
+                "c7c6d5d6-Make2DGridPrimitive": {
+                    "name": "Make2DGridPrimitive",
+                    "inputs": {
+                        "nx": {
+                            "link": null,
+                            "default-value": 500,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "ny": {
+                            "link": null,
+                            "default-value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "sizeX": {
+                            "link": null,
+                            "default-value": [
+                                1.0,
+                                0.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "sizeY": {
+                            "link": null,
+                            "default-value": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "scale": {
+                            "link": null,
+                            "default-value": 1000.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "origin": {
+                            "link": null,
+                            "default-value": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "Direction": {
+                            "value": "XZ",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "XZ",
+                                    "XY",
+                                    "YZ"
+                                ]
+                            },
+                            "type": "enum XZ XY YZ"
+                        },
+                        "hasFaces": {
+                            "value": true,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "isCentered": {
+                            "value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        }
+                    },
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        536.716796875,
+                        196.93310546875024
+                    ],
+                    "options": []
+                },
+                "5c6e4897-scnoise": {
+                    "name": "scnoise",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "prim": {
+                            "link": "main:c7c6d5d6-Make2DGridPrimitive:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "ElementSize": {
+                            "link": null,
+                            "default-value": 50,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "scale": {
+                            "link": null,
+                            "default-value": [
+                                1.0,
+                                1.0,
+                                1.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "offset": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "Griddist": {
+                            "link": null,
+                            "default-value": 2,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "Pulsenum": {
+                            "link": null,
+                            "default-value": 3,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "Visualize": {
+                            "link": null,
+                            "default-value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        1429.3333333333326,
+                        246.6666666666663
+                    ],
+                    "options": [
+                        "VIEW"
+                    ],
+                    "customui-panel": {
+                        "Default": {
+                            "In Sockets": {
+                                "SRC": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/SRC",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 4117738921
+                                },
+                                "prim": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/prim",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 2476211432
+                                },
+                                "ElementSize": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/ElementSize",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 2983066446
+                                },
+                                "scale": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/scale",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float Vector 3"
+                                    },
+                                    "uuid": 894888688
+                                },
+                                "offset": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/offset",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Float"
+                                    },
+                                    "uuid": 3893388158
+                                },
+                                "Griddist": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/Griddist",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 80002945
+                                },
+                                "Pulsenum": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/Pulsenum",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Integer"
+                                    },
+                                    "uuid": 681543121
+                                },
+                                "Visualize": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/inputs/Visualize",
+                                        "class": "input"
+                                    },
+                                    "control": {
+                                        "name": "Boolean"
+                                    },
+                                    "uuid": 529917360
+                                }
+                            },
+                            "Parameters": {},
+                            "Out Sockets": {
+                                "prim": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/outputs/prim",
+                                        "class": "output"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 4034227986
+                                },
+                                "DST": {
+                                    "core-param": {
+                                        "name": "main:5c6e4897-scnoise:[node]/outputs/DST",
+                                        "class": "output"
+                                    },
+                                    "control": {
+                                        "name": ""
+                                    },
+                                    "uuid": 763750700
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "view_rect": {}
+        },
+        "scnoise": {
+            "nodes": {
+                "f693dd8e-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": "",
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "name": {
+                            "value": "prim",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -981.0,
+                        106.0
+                    ],
+                    "options": []
+                },
+                "e3de6b8a-SubOutput": {
+                    "name": "SubOutput",
+                    "inputs": {
+                        "port": {
+                            "link": "scnoise:5e005d8c-IfElse:[node]/outputs/result",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": "",
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "name": {
+                            "value": "prim",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "DST": {}
+                    },
+                    "uipos": [
+                        7177.666666666666,
+                        1048.666666666667
+                    ],
+                    "options": []
+                },
+                "99b575b3-erode_noise_sparse_convolution": {
+                    "name": "erode_noise_sparse_convolution",
+                    "inputs": {
+                        "prim_2DGrid": {
+                            "link": "scnoise:e69966b4-ParticlesWrangle:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "posLikeAttrName": {
+                            "link": null,
+                            "default-value": "pos",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "pulsenum": {
+                            "link": "scnoise:d16ff22a-SubInput:[node]/outputs/port",
+                            "default-value": 3,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "griddist": {
+                            "link": "scnoise:e4964ad9-SubInput:[node]/outputs/port",
+                            "default-value": 2,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "attrName": {
+                            "value": "noise",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "attrType": {
+                            "value": "float3",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "float",
+                                    "float3"
+                                ]
+                            },
+                            "type": "enum float float3"
+                        }
+                    },
+                    "outputs": {
+                        "prim_2DGrid": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        2023.0,
+                        866.0
+                    ],
+                    "options": []
+                },
+                "a25af0bf-ParticlesWrangle": {
+                    "name": "ParticlesWrangle",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:99b575b3-erode_noise_sparse_convolution:[node]/outputs/prim_2DGrid",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "PrimitiveObject"
+                        },
+                        "zfxCode": {
+                            "link": null,
+                            "default-value": "@pos = @orignalPos\n@clr = (@noise.x + 1)*0.75\n\n\n",
+                            "control": {
+                                "name": "Multiline String"
+                            },
+                            "type": "string"
+                        },
+                        "params": {
+                            "property": "dict-panel",
+                            "dictlist-panel": {
+                                "collasped": false,
+                                "keys": {}
+                            },
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "dict"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        3047.507161458332,
+                        748.2753906250002
+                    ],
+                    "options": []
+                },
+                "e69966b4-ParticlesWrangle": {
+                    "name": "ParticlesWrangle",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:f693dd8e-SubInput:[node]/outputs/port",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "PrimitiveObject"
+                        },
+                        "zfxCode": {
+                            "link": null,
+                            "default-value": "@orignalPos = @pos\n\nfrequency = 1 / ($elesize * $scale + 0.00001)\noffset = $offset * frequency\n\ntemp_pos = @pos * frequency + offset\n\n@pos = temp_pos\n@clr = vec3(1,1,1)\n\n",
+                            "control": {
+                                "name": "Multiline String"
+                            },
+                            "type": "string"
+                        },
+                        "params": {
+                            "property": "dict-panel",
+                            "dictlist-panel": {
+                                "collasped": false,
+                                "keys": {
+                                    "elesize": {
+                                        "link": "scnoise:16b4da24-SubInput:[node]/outputs/port"
+                                    },
+                                    "scale": {
+                                        "link": "scnoise:c6e64d6e-SubInput:[node]/outputs/port"
+                                    },
+                                    "offset": {
+                                        "link": "scnoise:e24d32a7-SubInput:[node]/outputs/port"
+                                    }
+                                }
+                            },
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "dict"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        790.748046875,
+                        602.0869140624999
+                    ],
+                    "options": []
+                },
+                "16b4da24-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "ElementSize",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -1065.0,
+                        1077.0
+                    ],
+                    "options": []
+                },
+                "c6e64d6e-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "name": {
+                            "value": "scale",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "vec3f",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -1239.0,
+                        1377.6666666666666
+                    ],
+                    "options": []
+                },
+                "e24d32a7-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "name": {
+                            "value": "offset",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "float",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        -284.0,
+                        1592.0
+                    ],
+                    "options": []
+                },
+                "e4964ad9-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "Griddist",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        1154.0,
+                        30.0
+                    ],
+                    "options": []
+                },
+                "d16ff22a-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": 0,
+                            "control": {
+                                "name": "Integer"
+                            },
+                            "type": "int"
+                        },
+                        "name": {
+                            "value": "Pulsenum",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "int",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        1748.0,
+                        102.0
+                    ],
+                    "options": []
+                },
+                "440e96f5-SubInput": {
+                    "name": "SubInput",
+                    "inputs": {
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "defl": {
+                            "value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "name": {
+                            "value": "Visualize",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "type": {
+                            "value": "bool",
+                            "control": {
+                                "name": "Enum",
+                                "items": [
+                                    "",
+                                    "int",
+                                    "bool",
+                                    "float",
+                                    "string",
+                                    "vec2f",
+                                    "vec2i",
+                                    "vec3f",
+                                    "vec3i",
+                                    "vec4f",
+                                    "vec4i",
+                                    "color",
+                                    "curve",
+                                    "list",
+                                    "dict"
+                                ]
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "port": {},
+                        "hasValue": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        5045.333333333332,
+                        1160.0000000000003
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                },
+                "be2ad7b6-VisVec3Attribute": {
+                    "name": "VisVec3Attribute",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:d3809a07-ParticlesWrangle:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "name": {
+                            "link": null,
+                            "default-value": "vel2",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        },
+                        "normalize": {
+                            "link": null,
+                            "default-value": true,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "lengthScale": {
+                            "link": null,
+                            "default-value": 20.0,
+                            "control": {
+                                "name": "Float"
+                            },
+                            "type": "float"
+                        },
+                        "color": {
+                            "link": null,
+                            "default-value": [
+                                0.0,
+                                1.0,
+                                0.0
+                            ],
+                            "control": {
+                                "name": "Float Vector 3"
+                            },
+                            "type": "vec3f"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "primVis": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        5088.333333333334,
+                        1451.9999999999996
+                    ],
+                    "options": []
+                },
+                "5e005d8c-IfElse": {
+                    "name": "IfElse",
+                    "inputs": {
+                        "true": {
+                            "link": "scnoise:c8160976-PrimitiveDelAttr:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "false": {
+                            "link": "scnoise:d2108050-PrimitiveDelAttr:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "cond": {
+                            "link": "scnoise:440e96f5-SubInput:[node]/outputs/port",
+                            "default-value": false,
+                            "control": {
+                                "name": "Boolean"
+                            },
+                            "type": "bool"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "result": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        6510.000000000004,
+                        1054.6666666666666
+                    ],
+                    "options": []
+                },
+                "d3809a07-ParticlesWrangle": {
+                    "name": "ParticlesWrangle",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:d2108050-PrimitiveDelAttr:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "PrimitiveObject"
+                        },
+                        "zfxCode": {
+                            "link": null,
+                            "default-value": "@vel2 = vec3(@noise.z, 0.0, -@noise.y)\n\n",
+                            "control": {
+                                "name": "Multiline String"
+                            },
+                            "type": "string"
+                        },
+                        "params": {
+                            "property": "dict-panel",
+                            "dictlist-panel": {
+                                "collasped": false,
+                                "keys": {}
+                            },
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": "dict"
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {},
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        4369.733333333335,
+                        1253.9999999999996
+                    ],
+                    "options": []
+                },
+                "c8160976-PrimitiveDelAttr": {
+                    "name": "PrimitiveDelAttr",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:be2ad7b6-VisVec3Attribute:[node]/outputs/primVis",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "name": {
+                            "value": "vel2",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        5820.666666666673,
+                        1501.3333333333333
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                },
+                "d2108050-PrimitiveDelAttr": {
+                    "name": "PrimitiveDelAttr",
+                    "inputs": {
+                        "prim": {
+                            "link": "scnoise:a25af0bf-ParticlesWrangle:[node]/outputs/prim",
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        },
+                        "SRC": {
+                            "link": null,
+                            "default-value": null,
+                            "control": {
+                                "name": ""
+                            },
+                            "type": ""
+                        }
+                    },
+                    "params": {
+                        "name": {
+                            "value": "orignalPos",
+                            "control": {
+                                "name": "String"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "outputs": {
+                        "prim": {},
+                        "DST": {}
+                    },
+                    "uipos": [
+                        3953.3333333333378,
+                        836.0
+                    ],
+                    "options": [
+                        "collapsed"
+                    ]
+                }
+            },
+            "view_rect": {}
+        }
+    },
+    "views": {
+        "timeline": {
+            "start-frame": 0,
+            "end-frame": 0,
+            "curr-frame": 0,
+            "always": false
+        }
+    },
+    "descs": {
+        "AABBCollideDetect": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "bminA",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxA",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminB",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "overlap",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "AinsideB",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "BinsideA",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "AABBVoronoi": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bboxMin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bboxMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "numRandPoints",
+                    "64"
+                ],
+                [
+                    "bool",
+                    "periodicX",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicY",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicZ",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "AppendList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "Assign": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "AudioBeats": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "beat",
+                    ""
+                ],
+                [
+                    "",
+                    "var_H",
+                    ""
+                ],
+                [
+                    "",
+                    "H",
+                    ""
+                ],
+                [
+                    "",
+                    "E",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioEnergy": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "beat",
+                    ""
+                ],
+                [
+                    "",
+                    "E",
+                    ""
+                ],
+                [
+                    "",
+                    "uniE",
+                    ""
+                ],
+                [
+                    "",
+                    "minE",
+                    ""
+                ],
+                [
+                    "",
+                    "maxE",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioFFT": {
+            "inputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "float",
+                    "time",
+                    ""
+                ],
+                [
+                    "bool",
+                    "preEmphasis",
+                    "0"
+                ],
+                [
+                    "float",
+                    "preEmphasisAlpha",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hammingWindow",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioPowerVariation": {
+            "inputs": [
+                [
+                    "float",
+                    "sumpower",
+                    ""
+                ],
+                [
+                    "int",
+                    "winwidth",
+                    "20"
+                ],
+                [
+                    "int",
+                    "scale",
+                    "1"
+                ],
+                [
+                    "int",
+                    "maximum",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "powvar",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "AudioSumPower": {
+            "inputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "sumpower",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "BVHNearestAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "string",
+                    "bvhIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "bvhWeightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "string",
+                    "bvhAttrTag",
+                    "bvh_attr"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "BVHNearestPos": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "string",
+                    "bvhIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "bvhWeightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "string",
+                    "bvhPosTag",
+                    "bvh_pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "BackupField": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "BecomeRtInst": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isInst",
+                    "1"
+                ],
+                [
+                    "string",
+                    "instID",
+                    "Inst1"
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BeginFor": {
+            "inputs": [
+                [
+                    "int",
+                    "count",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BeginForEach": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BeginSubstep": {
+            "inputs": [
+                [
+                    "float",
+                    "total_dt",
+                    ""
+                ],
+                [
+                    "float",
+                    "min_scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "float",
+                    "elapsed_time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BindLight": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "islight",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "invertdir",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BindMaterial": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "mtlid",
+                    "Mat1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "BindRtInst": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "instID",
+                    "Inst1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "Blackboard": {
+            "inputs": [],
+            "params": [],
+            "outputs": [],
+            "categories": [
+                "layout"
+            ]
+        },
+        "BoundingBoxFitInto": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "bminSrc",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxSrc",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminDst",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxDst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bminTrans",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmaxTrans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "BreakFor": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "bool",
+                    "breaks",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "BuildPrimitiveBvh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "thickness",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum auto point line tri quad",
+                    "prim_type",
+                    "auto"
+                ]
+            ],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "BulletCalcInverseKinematics": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "endEffectorLinkIndices",
+                    ""
+                ],
+                [
+                    "",
+                    "targetPositions",
+                    ""
+                ],
+                [
+                    "",
+                    "targetOrientations",
+                    ""
+                ],
+                [
+                    "int",
+                    "numIterations",
+                    "20"
+                ],
+                [
+                    "float",
+                    "residualThreshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum VEL_DLS_ORI_NULL VEL_SDLS_ORI VEL_DLS_ORI VEL_DLS_NULL VEL_SDLS VEL_DLS JACOB_TRANS",
+                    "IKMethod",
+                    "VEL_DLS_ORI_NULL"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "poses",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletColShapeCalcLocalInertia": {
+            "inputs": [
+                [
+                    "",
+                    "colObject",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isCompound",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "localInertia",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletComposeTransform": {
+            "inputs": [
+                [
+                    "",
+                    "transFirst",
+                    ""
+                ],
+                [
+                    "",
+                    "transSecond",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletCompoundAddChild": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "childShape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintDisplay": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "nlist",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintGetFrames": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "frame1",
+                    ""
+                ],
+                [
+                    "",
+                    "frame2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetAxis": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "axis1",
+                    ""
+                ],
+                [
+                    "",
+                    "axis2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Fixed Gear Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Point2Point Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetBreakThres": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "threshold",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetFrames": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "frame1",
+                    ""
+                ],
+                [
+                    "",
+                    "frame2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetLimitByAxis": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "lowLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "highLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum ConeTwist Fixed Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Slider Universal",
+                    "constraintType",
+                    "Universal"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetMotor": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "bounce",
+                    ""
+                ],
+                [
+                    "bool",
+                    "enableMotor",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "enableServo",
+                    "1"
+                ],
+                [
+                    "float",
+                    "maxMotorForce",
+                    ""
+                ],
+                [
+                    "float",
+                    "servoTarget",
+                    ""
+                ],
+                [
+                    "float",
+                    "targetVelocity",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulse",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulseNormalized",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "motorTarget",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "motorTargetConstraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "angularOnly",
+                    ""
+                ],
+                [
+                    "float",
+                    "fixThresh",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum ConeTwist Generic6Dof Generic6DofSpring2 Hinge Hinge2",
+                    "constraintType",
+                    "ConeTwist"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetRefFrameA": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Generic6Dof Generic6DofSpring Hinge Universal",
+                    "constraintType",
+                    "Universal"
+                ],
+                [
+                    "enum true false",
+                    "useReferenceFrameA",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetRotOrder": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Generic6DofSpring2 Hinge2",
+                    "constraintType",
+                    "Hinge2"
+                ],
+                [
+                    "enum XYZ XZY YXZ YZX ZXY ZYX",
+                    "rotateOrder",
+                    "XYZ"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletConstraintSetSpring": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "bool",
+                    "enable",
+                    "0"
+                ],
+                [
+                    "",
+                    "stiffness",
+                    ""
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "equilibriumPointVal",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum linearX linearY linearZ angularX angularY angularZ",
+                    "axisId",
+                    "linearX"
+                ],
+                [
+                    "enum Fixed Generic6DofSpring Generic6DofSpring2 Hinge2",
+                    "constraintType",
+                    "Fixed"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletExtractTransform": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGearConstraintSetRatio": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "float",
+                    "ratio",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGetAABB": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "aabbMin",
+                    ""
+                ],
+                [
+                    "",
+                    "aabbMax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGlueCompoundAddChild": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "childShape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletGlueCompoundUpdateGlueList": {
+            "inputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "glueListVec2i",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletInverseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans_inv",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeBoxShape": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "semiSize",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCapsuleShape": {
+            "inputs": [
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCompoundShape": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "compound",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "int",
+                    "iternum",
+                    "100"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum ConeTwist Fixed Gear Generic6Dof Generic6DofSpring Generic6DofSpring2 Hinge Hinge2 Point2Point Slider Universal",
+                    "constraintType",
+                    "Fixed"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConvexHullShape": {
+            "inputs": [
+                [
+                    "",
+                    "triMesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "margin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeConvexMeshShape": {
+            "inputs": [
+                [
+                    "",
+                    "triMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeCylinderShape": {
+            "inputs": [
+                [
+                    "",
+                    "halfExtents",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeFrameFromPivotAxis": {
+            "inputs": [
+                [
+                    "",
+                    "pivot",
+                    ""
+                ],
+                [
+                    "",
+                    "axis",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "frame",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeGlueCompoundShape": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeMultiBodyWorld": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum SequentialImpulse ProjectedGaussSeidel Dantzig",
+                    "solverType",
+                    "SequentialImpulse"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeObject": {
+            "inputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeSphereShape": {
+            "inputs": [
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeStaticPlaneShape": {
+            "inputs": [
+                [
+                    "",
+                    "planeNormal",
+                    ""
+                ],
+                [
+                    "float",
+                    "planeConstant",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "shape",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeTransform": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "translate",
+                    ""
+                ],
+                [
+                    "",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMakeWorld": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyAddJointTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyApplyExternalForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "force",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyApplyExternalTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyCalculateJacobian": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "localPos",
+                    ""
+                ],
+                [
+                    "",
+                    "jointPositionsQ",
+                    ""
+                ],
+                [
+                    "",
+                    "jointVelocitiesQd",
+                    ""
+                ],
+                [
+                    "",
+                    "jointAccelerations",
+                    ""
+                ],
+                [
+                    "",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jacobian_linear",
+                    ""
+                ],
+                [
+                    "",
+                    "jacobian_angular",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyCalculateMassMatrix": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jointPositionsQ",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "mass_matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyClearJointStates": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyForwardKinematics": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBaseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBaseVelocity": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetBodyId": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "id",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetContactPoints": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "contactPointsList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetJointTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "jointIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetJointVelPos": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vel",
+                    ""
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetLinkForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "force",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetLinkTorque": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "torque",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetNumBodies": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "numBodies",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyLinkColliderSetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyLinkGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyMakeConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "bodyA",
+                    ""
+                ],
+                [
+                    "",
+                    "linkA",
+                    ""
+                ],
+                [
+                    "",
+                    "bodyB",
+                    ""
+                ],
+                [
+                    "",
+                    "linkB",
+                    ""
+                ],
+                [
+                    "",
+                    "lowerLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "upperLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "twistLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "jointMaxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "desiredVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Default DefaultMotor Spherical SphericalMotor Fixed Gear Point2Point Slider",
+                    "constraintType",
+                    "Default"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyMakeJointMotor": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "int",
+                    "linkDof",
+                    "0"
+                ],
+                [
+                    "float",
+                    "desiredVelocity",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxMotorImpulse",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyObjectMakeEnd": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyObjectMakeStart": {
+            "inputs": [
+                [
+                    "",
+                    "nLinks",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "inertia",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "canSleep",
+                    "true"
+                ],
+                [
+                    "enum true false",
+                    "fixedBase",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyPDControl": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "kp",
+                    ""
+                ],
+                [
+                    "float",
+                    "kd",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "qDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "dqDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyRemoveBody": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "id",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyResetSimulation": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetBaseTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "baseTrans",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetCollider": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetCollisionShapeForLink": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "colShape",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointFeedback": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointPosMultiDof": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "startIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isSpherical",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointProperty": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "linkIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "friction",
+                    ""
+                ],
+                [
+                    "",
+                    "lowerLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "upperLimit",
+                    ""
+                ],
+                [
+                    "",
+                    "maxForce",
+                    ""
+                ],
+                [
+                    "",
+                    "maxVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetJointVelMultiDof": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "int",
+                    "startIndex",
+                    "0"
+                ],
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isSpherical",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetProperty": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "linearDamp",
+                    ""
+                ],
+                [
+                    "float",
+                    "angularDamp",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "canSleep",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "selfCollide",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "useGyro",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodySetupJoint": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "linkIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "parentIndex",
+                    ""
+                ],
+                [
+                    "",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "inertia",
+                    ""
+                ],
+                [
+                    "",
+                    "jointAxis",
+                    ""
+                ],
+                [
+                    "",
+                    "rotParentToThis",
+                    ""
+                ],
+                [
+                    "",
+                    "parentComToThisPivotOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "thisPivotToThisComOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "disableParentCollision",
+                    "false"
+                ],
+                [
+                    "enum Fixed Prismatic Revolute Spherical Planar",
+                    "jointType",
+                    "Revolute"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyUpdateColObjectTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddCollisionObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "isDynamic",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddConstraintEnd": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldAddObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum rigid multi",
+                    "objType",
+                    "multi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldGetTransformShapes": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "visualMap",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transList",
+                    ""
+                ],
+                [
+                    "",
+                    "visualList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldRemoveConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldRemoveObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum rigid multi",
+                    "objType",
+                    "multi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletMultiBodyWorldSetGravity": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectApplyForce": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "ForceImpulse",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "TorqueImpulse",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectGetTransform": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectGetVel": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "linearVel",
+                    ""
+                ],
+                [
+                    "",
+                    "angularVel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetDamping": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "dampLin",
+                    ""
+                ],
+                [
+                    "float",
+                    "dampAug",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetFriction": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "friction",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletObjectSetRestitution": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "float",
+                    "restitution",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletQuatRotate": {
+            "inputs": [
+                [
+                    "",
+                    "quat",
+                    ""
+                ],
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletResetSimulation": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletSetContactParameters": {
+            "inputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "lateralFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "restitution",
+                    ""
+                ],
+                [
+                    "",
+                    "rollingFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "spinningFriction",
+                    ""
+                ],
+                [
+                    "",
+                    "stiffness",
+                    ""
+                ],
+                [
+                    "",
+                    "damping",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "frictionAnchor",
+                    "false"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "collider",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "BulletSliderConstraintSetSpring": {
+            "inputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "dampingOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "maxAngMotorForce",
+                    ""
+                ],
+                [
+                    "",
+                    "maxLinMotorForce",
+                    ""
+                ],
+                [
+                    "",
+                    "poweredAngMotor",
+                    ""
+                ],
+                [
+                    "",
+                    "poweredLinMotor",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "restitutionOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessDirAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessDirLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessLimAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessLimLin",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessOrthoAng",
+                    ""
+                ],
+                [
+                    "",
+                    "softnessOrthoLin",
+                    ""
+                ],
+                [
+                    "",
+                    "targetAngMotorVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "targetLinMotorVelocity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletStepMultiBodyWorld": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "int",
+                    "maxSubSteps",
+                    "1"
+                ],
+                [
+                    "float",
+                    "fixedTimeStep",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletStepWorld": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "int",
+                    "steps",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletTransformSetBasisEuler": {
+            "inputs": [
+                [
+                    "",
+                    "trans",
+                    ""
+                ],
+                [
+                    "",
+                    "eulerZYX",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldAddConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldAddObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldRemoveConstraint": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "constraint",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldRemoveObject": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetConsList": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "consList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetGravity": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "gravity",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "BulletWorldSetObjList": {
+            "inputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "objList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "CacheLastFrameBegin": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "linkFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "lastFrame",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CacheLastFrameEnd": {
+            "inputs": [
+                [
+                    "",
+                    "linkTo",
+                    ""
+                ],
+                [
+                    "",
+                    "updateCache",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CachePrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "inPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "dir",
+                    "/tmp/cache"
+                ],
+                [
+                    "bool",
+                    "ignore",
+                    "0"
+                ],
+                [
+                    "string",
+                    "prefix",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CacheVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "inGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "dir",
+                    "/tmp/cache"
+                ],
+                [
+                    "bool",
+                    "ignore",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "mute",
+                    "0"
+                ],
+                [
+                    "string",
+                    "prefix",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "CachedByKey": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CachedIf": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "keepCache",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CachedOnce": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "CalcDirectionFromAngle": {
+            "inputs": [
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "enum XY YX YZ ZY ZX XZ",
+                    "plane",
+                    "XY"
+                ],
+                [
+                    "float",
+                    "length",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "CalcGeometryUV": {
+            "inputs": [
+                [
+                    "readpath",
+                    "objpath",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "CalculateResidual2": {
+            "inputs": [
+                [
+                    "",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "CameraEval": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "nodelist",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Bezier Linear ",
+                    "inter",
+                    "Bezier"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "CameraNode": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "string",
+                    "other",
+                    ""
+                ],
+                [
+                    "int",
+                    "frame",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "CameraObject",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "CihouMayaCameraFov": {
+            "inputs": [
+                [
+                    "enum Horizontal Vertical",
+                    "fit_gate",
+                    "Horizontal"
+                ],
+                [
+                    "float",
+                    "focL",
+                    ""
+                ],
+                [
+                    "float",
+                    "fw",
+                    ""
+                ],
+                [
+                    "float",
+                    "fh",
+                    ""
+                ],
+                [
+                    "float",
+                    "nx",
+                    ""
+                ],
+                [
+                    "float",
+                    "ny",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "Clone": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "newObject",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "CombineVDB": {
+            "inputs": [
+                [
+                    "",
+                    "FieldA",
+                    ""
+                ],
+                [
+                    "",
+                    "FieldB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "MultiplierA",
+                    ""
+                ],
+                [
+                    "float",
+                    "MultiplierB",
+                    ""
+                ],
+                [
+                    "enum CSGUnion CSGIntersection CSGDifference Add Mul Replace A_Sample_B",
+                    "OpType",
+                    "CSGUnion"
+                ],
+                [
+                    "bool",
+                    "writeBack",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "FieldOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "CompressibleAdvection": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "RK_Order",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CompressibleMarkDOF": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CompressibleProjection": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "RK_Order",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "CopyAllUserData": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "CreateBezierCurve": {
+            "inputs": [
+                [
+                    "list",
+                    "CustomPoints",
+                    ""
+                ],
+                [
+                    "prim",
+                    "SamplePoints",
+                    ""
+                ],
+                [
+                    "float",
+                    "precision",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "SampleAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "SampleTag",
+                    ""
+                ],
+                [
+                    "enum Bezier",
+                    "Type",
+                    "Bezier"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "curev",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCircle": {
+            "inputs": [
+                [
+                    "int",
+                    "segments",
+                    "32"
+                ],
+                [
+                    "float",
+                    "r",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "CreateCone": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "lons",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCube": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "int",
+                    "div_w",
+                    "2"
+                ],
+                [
+                    "int",
+                    "div_h",
+                    "2"
+                ],
+                [
+                    "int",
+                    "div_d",
+                    "2"
+                ],
+                [
+                    "float",
+                    "size",
+                    ""
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateCylinder": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "lons",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateDisk": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "int",
+                    "divisions",
+                    "32"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreatePlane": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "size",
+                    ""
+                ],
+                [
+                    "int",
+                    "rows",
+                    "1"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreatePoint": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateSphere": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "int",
+                    "rows",
+                    "12"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "24"
+                ],
+                [
+                    "bool",
+                    "quads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CreateTube": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaleSize",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasNormal",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "hasVertUV",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isFlipFace",
+                    "0"
+                ],
+                [
+                    "float",
+                    "radius1",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius2",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "int",
+                    "rows",
+                    "3"
+                ],
+                [
+                    "int",
+                    "columns",
+                    "12"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "create"
+            ]
+        },
+        "CurveOrientation": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirName",
+                    "dir"
+                ],
+                [
+                    "string",
+                    "tanName",
+                    "tan"
+                ],
+                [
+                    "string",
+                    "bitanName",
+                    "bitan"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Curvemap": {
+            "inputs": [
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "res",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "DegreetoRad": {
+            "inputs": [
+                [
+                    "float",
+                    "degree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "radian",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "DelUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "DemBones": {
+            "inputs": [
+                [
+                    "",
+                    "BakedPrimList",
+                    ""
+                ],
+                [
+                    "",
+                    "RefPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "bone_number",
+                    "20"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "BoneBindInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "SkiningInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "FrameInfo",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "DemBones"
+            ]
+        },
+        "DenseFieldToVDB": {
+            "inputs": [
+                [
+                    "",
+                    "inDenseField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "VDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "DictEraseItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictGetItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "defl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "zany",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictGetKeyList": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ListObject",
+                    "keys",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictHasKey": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "hasKey",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictSetItem": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    ""
+                ],
+                [
+                    "zany",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictSize": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DictUnion": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict1",
+                    ""
+                ],
+                [
+                    "DictObject",
+                    "dict2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "DynamicNumber": {
+            "inputs": [
+                [
+                    "",
+                    "frame",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum 100 10 1 0.1 0.01 0.001",
+                    "speed",
+                    "1"
+                ],
+                [
+                    "enum clamp zero cycle",
+                    "type",
+                    "clamp"
+                ],
+                [
+                    "floatslider",
+                    "w",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "x",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "y",
+                    "0"
+                ],
+                [
+                    "floatslider",
+                    "z",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "x",
+                    ""
+                ],
+                [
+                    "",
+                    "y",
+                    ""
+                ],
+                [
+                    "",
+                    "z",
+                    ""
+                ],
+                [
+                    "",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "EmptyDict": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "EmptyList": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "EndFor": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "EndForEach": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "bool",
+                    "accept",
+                    "1"
+                ],
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doConcat",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "droppedList",
+                    ""
+                ],
+                [
+                    "",
+                    "accumate",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "EvalCurve": {
+            "inputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "EvalCurveOnPrimAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "dstName",
+                    ""
+                ],
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "EvalFBXAnim": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "float",
+                    "fps",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum TRUE FALSE",
+                    "interAnimData",
+                    "FALSE"
+                ],
+                [
+                    "bool",
+                    "printAnimData",
+                    "0"
+                ],
+                [
+                    "enum FROM_MAYA DEFAULT",
+                    "unit",
+                    "FROM_MAYA"
+                ],
+                [
+                    "bool",
+                    "writeData",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "light",
+                    ""
+                ],
+                [
+                    "",
+                    "matName",
+                    ""
+                ],
+                [
+                    "",
+                    "meshName",
+                    ""
+                ],
+                [
+                    "",
+                    "bsPrims",
+                    ""
+                ],
+                [
+                    "",
+                    "bsPrimsOrigin",
+                    ""
+                ],
+                [
+                    "",
+                    "transDict",
+                    ""
+                ],
+                [
+                    "",
+                    "quatDict",
+                    ""
+                ],
+                [
+                    "",
+                    "scaleDict",
+                    ""
+                ],
+                [
+                    "",
+                    "writeData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExchangeFBXData": {
+            "inputs": [
+                [
+                    "",
+                    "d",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum DATA DATAS MATS",
+                    "dType",
+                    "DATA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "d",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExportFBX": {
+            "inputs": [
+                [
+                    "string",
+                    "custom_command",
+                    ""
+                ],
+                [
+                    "string",
+                    "extra_param",
+                    " -b=5"
+                ],
+                [
+                    "string",
+                    "abcpath",
+                    ""
+                ],
+                [
+                    "string",
+                    "fbxpath",
+                    ""
+                ],
+                [
+                    "string",
+                    "outpath",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExportObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportParticles": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportUVObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "ExportVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExportZpmPrimitive": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExtendList": {
+            "inputs": [
+                [
+                    "",
+                    "list1",
+                    ""
+                ],
+                [
+                    "",
+                    "list2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list1",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ExtractAxis": {
+            "inputs": [
+                [
+                    "AxisObject",
+                    "math",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisZ",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "ExtractCameraData": {
+            "inputs": [
+                [
+                    "string",
+                    "key",
+                    "camera1"
+                ],
+                [
+                    "",
+                    "camobject",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pos",
+                    ""
+                ],
+                [
+                    "",
+                    "up",
+                    ""
+                ],
+                [
+                    "",
+                    "view",
+                    ""
+                ],
+                [
+                    "",
+                    "focL",
+                    ""
+                ],
+                [
+                    "",
+                    "haov",
+                    ""
+                ],
+                [
+                    "",
+                    "waov",
+                    ""
+                ],
+                [
+                    "",
+                    "hfov",
+                    ""
+                ],
+                [
+                    "",
+                    "filmW",
+                    ""
+                ],
+                [
+                    "",
+                    "filmH",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "ExtractFBXData": {
+            "inputs": [
+                [
+                    "FBXData",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IVertices",
+                    "vertices",
+                    ""
+                ],
+                [
+                    "IIndices",
+                    "indices",
+                    ""
+                ],
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "IBoneOffset",
+                    "boneOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractLegacyDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ExtractList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ExtractMatData": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum V1 V2",
+                    "texVer",
+                    "V1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "datas",
+                    ""
+                ],
+                [
+                    "",
+                    "matName",
+                    ""
+                ],
+                [
+                    "",
+                    "texLists",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatDict": {
+            "inputs": [
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mats",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatName": {
+            "inputs": [
+                [
+                    "",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "key",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "name",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ExtractMatTexList": {
+            "inputs": [
+                [
+                    "IMaterial",
+                    "material",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "texLists",
+                    ""
+                ],
+                [
+                    "",
+                    "name",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "FFPlayAudioFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "bool",
+                    "nodisp",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "wait",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "FileReadString": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "FileWriteString": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "FuncBegin": {
+            "inputs": [
+                [
+                    "",
+                    "extraArgs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncCall": {
+            "inputs": [
+                [
+                    "FunctionObject",
+                    "function",
+                    ""
+                ],
+                [
+                    "FunctionObject",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "FunctionObject",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncCallInDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "funcDict",
+                    ""
+                ],
+                [
+                    "bool",
+                    "mayNotFound",
+                    "1"
+                ],
+                [
+                    "string",
+                    "dictKey",
+                    ""
+                ],
+                [
+                    "DictObject",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncEnd": {
+            "inputs": [
+                [
+                    "",
+                    "rets",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleBegin": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "arg",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleCall": {
+            "inputs": [
+                [
+                    "FunctionObject",
+                    "function",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "arg",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleCallInDict": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "funcDict",
+                    ""
+                ],
+                [
+                    "string",
+                    "dictKey",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "arg",
+                    ""
+                ],
+                [
+                    "bool",
+                    "mayNotFound",
+                    "1"
+                ],
+                [
+                    "IObject",
+                    "notFoundRet",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "isFound",
+                    "0"
+                ],
+                [
+                    "IObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "FuncSimpleEnd": {
+            "inputs": [
+                [
+                    "",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "FUNC",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "Gather2DFiniteDifference": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "string",
+                    "channel",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum FIVE_STENCIL NINE_STENCIL",
+                    "OpType",
+                    "FIVE_STENCIL"
+                ],
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "GeoVertexVel": {
+            "inputs": [
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "TargetMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "OriginMesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "MeshVel",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "GetCurveControlPoint": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "point_x",
+                    ""
+                ],
+                [
+                    "float",
+                    "point_y",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "left_handler",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "right_handler",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "GetDenseField": {
+            "inputs": [
+                [
+                    "",
+                    "inSolverData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "FieldName",
+                    "p u rho"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outDenseField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "GetFrameNum": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FrameNum",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFramePortion": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FramePortion",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetFrameTimeElapsed": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetPerlinNoise": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "freq",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "noise",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "noise"
+            ]
+        },
+        "GetTime": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "GetUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasValue",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "GetVDBBound": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "GetVDBPoints": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "GetVDBPointsDroplets": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "GetVDBVoxelSize": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dx",
+                    ""
+                ],
+                [
+                    "",
+                    "dy",
+                    ""
+                ],
+                [
+                    "",
+                    "dz",
+                    ""
+                ],
+                [
+                    "",
+                    "dxyz",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "Grid2DSample": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "float",
+                    "h",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "string",
+                    "channel",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "sampleBy",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "Group": {
+            "inputs": [],
+            "params": [],
+            "outputs": [],
+            "categories": [
+                "layout"
+            ]
+        },
+        "HDRSky": {
+            "inputs": [
+                [
+                    "bool",
+                    "enable",
+                    "1"
+                ],
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "float",
+                    "rotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotation3d",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "HDRSky",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "HeightStarPattern": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "float",
+                    "anglerandom",
+                    ""
+                ],
+                [
+                    "float",
+                    "shapesize",
+                    ""
+                ],
+                [
+                    "float",
+                    "posjitter",
+                    ""
+                ],
+                [
+                    "float",
+                    "sharpness",
+                    ""
+                ],
+                [
+                    "float",
+                    "starness",
+                    ""
+                ],
+                [
+                    "int",
+                    "sides",
+                    "5"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "HelperMute": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "NOTE",
+                    "Dont-use-this-node-directly"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "HelperOnce": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "NOTE",
+                    "Dont-use-this-node-directly"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "INTERN_PreViewVDB": {
+            "inputs": [
+                [
+                    "",
+                    "arg0",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "ret0",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "IfElse": {
+            "inputs": [
+                [
+                    "",
+                    "true",
+                    ""
+                ],
+                [
+                    "",
+                    "false",
+                    ""
+                ],
+                [
+                    "bool",
+                    "cond",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "ImportObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportObjPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportParticles": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ImportZpmPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "InitField": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "IntegrateFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "desired_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "min_scale",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "actual_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "IsList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "IslandVoronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "LightNode": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "position",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "color",
+                    ""
+                ],
+                [
+                    "float",
+                    "intensity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "islight",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "invertdir",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Disk Plane",
+                    "Shape",
+                    "Plane"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "LineAddVert": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vert",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "LineCarve": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "insertU",
+                    ""
+                ],
+                [
+                    "bool",
+                    "cut",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "cut insert to end",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "LineResample": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "segments",
+                    "3"
+                ],
+                [
+                    "",
+                    "PrimSampler",
+                    ""
+                ],
+                [
+                    "string",
+                    "SampleBy",
+                    "t"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ListGetItem": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "ListLength": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "length",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "LiveMeshNode": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "string",
+                    "vertSrc",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prims",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "LoadSampleModel": {
+            "inputs": [
+                [
+                    "enum cube monkey sphere humannose Pig_Head temple star",
+                    "name",
+                    "cube"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "decodeUVs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "LoadStringPrim": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "Zello World!"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make1DLinePrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "n",
+                    "2"
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum X Y Z",
+                    "Direction",
+                    "X"
+                ],
+                [
+                    "bool",
+                    "hasLines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make2DGridPrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "2"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "sizeX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeY",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum XZ XY YZ",
+                    "Direction",
+                    "XZ"
+                ],
+                [
+                    "bool",
+                    "hasFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make3DGridPointsInAABB": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "4"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "int",
+                    "nz",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isStaggered",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "Make3DGridPrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "nx",
+                    "2"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "0"
+                ],
+                [
+                    "int",
+                    "nz",
+                    "0"
+                ],
+                [
+                    "vec3f",
+                    "sizeX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sizeZ",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isCentered",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeAxis": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisX",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisY",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axisZ",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum off X Y Z",
+                    "normalize",
+                    "off"
+                ]
+            ],
+            "outputs": [
+                [
+                    "AxisObject",
+                    "math",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakeBoxPrimitive": {
+            "inputs": [
+                [
+                    "float",
+                    "size_x",
+                    ""
+                ],
+                [
+                    "float",
+                    "size_y",
+                    ""
+                ],
+                [
+                    "float",
+                    "size_z",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "use_quads",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeCamera": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "pos",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "view",
+                    ""
+                ],
+                [
+                    "float",
+                    "near",
+                    ""
+                ],
+                [
+                    "float",
+                    "far",
+                    ""
+                ],
+                [
+                    "float",
+                    "fov",
+                    ""
+                ],
+                [
+                    "float",
+                    "aperture",
+                    ""
+                ],
+                [
+                    "float",
+                    "focalPlaneDistance",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "CameraObject",
+                    "camera",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeCompressibleFlow": {
+            "inputs": [
+                [
+                    "",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "dx",
+                    ""
+                ],
+                [
+                    "",
+                    "q_amb",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "CompressibleFlow",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MakeCubePrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "spacing",
+                    ""
+                ],
+                [
+                    "",
+                    "nx",
+                    ""
+                ],
+                [
+                    "",
+                    "ny",
+                    ""
+                ],
+                [
+                    "",
+                    "nz",
+                    ""
+                ],
+                [
+                    "",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MakeCurve": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "MakeCurvemap": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "input_max",
+                    ""
+                ],
+                [
+                    "float",
+                    "input_min",
+                    ""
+                ],
+                [
+                    "float",
+                    "output_max",
+                    ""
+                ],
+                [
+                    "float",
+                    "output_min",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MakeDict": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "MakeDummy": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dummy",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "MakeGCTest": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "value",
+                    "42"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "MakeHeatmap": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "nres",
+                    "1024"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "MakeInstancing": {
+            "inputs": [
+                [
+                    "int",
+                    "amount",
+                    "1"
+                ],
+                [
+                    "list",
+                    "modelMatrices",
+                    ""
+                ],
+                [
+                    "float",
+                    "deltaTime",
+                    ""
+                ],
+                [
+                    "list",
+                    "timeList",
+                    ""
+                ],
+                [
+                    "list",
+                    "framePrims",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "instancing",
+                    "inst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeJFNKSolver2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "JFNKSolverObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "MakeLight": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "lightDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "intensity",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shadowTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "lightHight",
+                    ""
+                ],
+                [
+                    "float",
+                    "shadowSoftness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "lightColor",
+                    ""
+                ],
+                [
+                    "float",
+                    "lightScale",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isEnabled",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LightObject",
+                    "light",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeList": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "MakeLocalSys": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "front",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "up",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "right",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "LocalSys",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakeMPMMehser": {
+            "inputs": [
+                [
+                    "",
+                    "pathPreFix",
+                    ""
+                ],
+                [
+                    "",
+                    "tet_path",
+                    ""
+                ],
+                [
+                    "",
+                    "smooth_iter",
+                    ""
+                ],
+                [
+                    "",
+                    "start",
+                    ""
+                ],
+                [
+                    "",
+                    "end",
+                    ""
+                ],
+                [
+                    "",
+                    "edge_stretch",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "MPMMehser",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "GPUMPM"
+            ]
+        },
+        "MakeMultilineString": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "multiline_string",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeNonlinearProblemObject2": {
+            "inputs": [
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "NonlinearProblemObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "MakeOrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MakePointPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakePrimitive": {
+            "inputs": [
+                [
+                    "int",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakePrimitiveFromList": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "MakeReadPath": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeShaderUniform": {
+            "inputs": [
+                [
+                    "int",
+                    "size",
+                    "512"
+                ],
+                [
+                    "",
+                    "uniformDict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeSmallDict": {
+            "inputs": [
+                [
+                    "string",
+                    "key0",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj0",
+                    ""
+                ],
+                [
+                    "string",
+                    "key1",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "string",
+                    "key2",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "string",
+                    "key3",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj3",
+                    ""
+                ],
+                [
+                    "string",
+                    "key4",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj4",
+                    ""
+                ],
+                [
+                    "string",
+                    "key5",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "obj5",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "MakeSmallList": {
+            "inputs": [
+                [
+                    "",
+                    "obj0",
+                    ""
+                ],
+                [
+                    "",
+                    "obj1",
+                    ""
+                ],
+                [
+                    "",
+                    "obj2",
+                    ""
+                ],
+                [
+                    "",
+                    "obj3",
+                    ""
+                ],
+                [
+                    "",
+                    "obj4",
+                    ""
+                ],
+                [
+                    "",
+                    "obj5",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doConcat",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "MakeString": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MakeTexture2D": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "enum REPEAT MIRRORED_REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrapS",
+                    "REPEAT"
+                ],
+                [
+                    "enum REPEAT MIRRORED_REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrapT",
+                    "REPEAT"
+                ],
+                [
+                    "enum NEAREST LINEAR NEAREST_MIPMAP_NEAREST LINEAR_MIPMAP_NEAREST NEAREST_MIPMAP_LINEAR LINEAR_MIPMAP_LINEAR",
+                    "minFilter",
+                    "LINEAR"
+                ],
+                [
+                    "enum NEAREST LINEAR NEAREST_MIPMAP_NEAREST LINEAR_MIPMAP_NEAREST NEAREST_MIPMAP_LINEAR LINEAR_MIPMAP_LINEAR",
+                    "magFilter",
+                    "LINEAR"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "texture",
+                    "tex",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "MakeVDBGrid": {
+            "inputs": [
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    ""
+                ],
+                [
+                    "enum vertex Centered Staggered",
+                    "structure",
+                    "Centered"
+                ],
+                [
+                    "enum float float3 int int3 points",
+                    "type",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "MakeVelocityPressure": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MakeVisualAABBPrimitive": {
+            "inputs": [
+                [
+                    "float",
+                    "dx",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "boundMin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "boundMax",
+                    ""
+                ],
+                [
+                    "int",
+                    "OpenTop",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum points edges trifaces quadfaces",
+                    "type",
+                    "edges"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "MakeWritePath": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "string",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "MarkMovingSolidCellsByVDB": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "simParam",
+                    ""
+                ],
+                [
+                    "",
+                    "SDFVDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "SolidVelVDBField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "MatTranspose": {
+            "inputs": [
+                [
+                    "",
+                    "mat",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "transposeMat",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "MelFilter": {
+            "inputs": [
+                [
+                    "",
+                    "FFTPrim",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "15"
+                ],
+                [
+                    "float",
+                    "sampleFreq",
+                    ""
+                ],
+                [
+                    "float",
+                    "rangePerFilter",
+                    ""
+                ],
+                [
+                    "enum none index indexdivcount",
+                    "indexType",
+                    "index"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FilterBank",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "MeshCopy": {
+            "inputs": [
+                [
+                    "",
+                    "copyFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "copyTo",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshMix": {
+            "inputs": [
+                [
+                    "",
+                    "meshA",
+                    ""
+                ],
+                [
+                    "",
+                    "meshB",
+                    ""
+                ],
+                [
+                    "",
+                    "coef",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MeshToSDF": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vertex cell",
+                    "type",
+                    "vertex"
+                ],
+                [
+                    "float",
+                    "voxel_size",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "MesherProcessFrame": {
+            "inputs": [
+                [
+                    "",
+                    "Mesher",
+                    ""
+                ],
+                [
+                    "",
+                    "frameNumber",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "FramePrimitive",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "GPUMPM"
+            ]
+        },
+        "MocDictAsInput": {
+            "inputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict2"
+            ]
+        },
+        "MocDictAsOutput": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict2"
+            ]
+        },
+        "MockList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list2"
+            ]
+        },
+        "MomentumTransfer2DFiniteDifference": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "nx",
+                    "1"
+                ],
+                [
+                    "int",
+                    "ny",
+                    "1"
+                ],
+                [
+                    "string",
+                    "channel",
+                    "d"
+                ],
+                [
+                    "string",
+                    "add_channel",
+                    "d"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum FIVE_STENCIL NINE_STENCIL",
+                    "OpType",
+                    "FIVE_STENCIL"
+                ],
+                [
+                    "enum vec3 float",
+                    "attrT",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "MoveAssign": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "MoveClone": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "newObject",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "MoveDelete": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "Noise_gabor_2d": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "a_",
+                    ""
+                ],
+                [
+                    "float",
+                    "F_0_",
+                    ""
+                ],
+                [
+                    "float",
+                    "omega_0_",
+                    ""
+                ],
+                [
+                    "int",
+                    "number_of_impulses_per_kernel",
+                    "64"
+                ],
+                [
+                    "int",
+                    "period",
+                    "256"
+                ],
+                [
+                    "bool",
+                    "isotropic",
+                    "0"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "NumRandom": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "dir",
+                    ""
+                ],
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum scalar01 scalar11 cube01 cube11 plane01 plane11 disk cylinder ball semiball sphere semisphere",
+                    "randType",
+                    "scalar01"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomFloat": {
+            "inputs": [
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "float",
+                    "valmin",
+                    ""
+                ],
+                [
+                    "float",
+                    "valmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomInt": {
+            "inputs": [
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "int",
+                    "valmin",
+                    "0"
+                ],
+                [
+                    "int",
+                    "valmax",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumRandomSeedCombine": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ],
+                [
+                    "int",
+                    "w",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "seed",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericCounter": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "count",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericEval": {
+            "inputs": [
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "enum float vec3f int string",
+                    "resType",
+                    "float"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericFloat": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericInt": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "value",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec2i",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec3": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3i",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericIntVec4": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec4f",
+                    "vec4",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericInterpolation": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "src",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "srcMin",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "srcMax",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dstMin",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dstMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "isClamped",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericOperator": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "lhs",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "rhs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum add sub mul div mod and or xor shr shl cmpge cmple cmpgt cmplt cmpne cmpeq land lor pos neg inv not atan2 pow max min fmod dot cross distance length normalize abs sqrt sin cos tan asin acos atan exp log floor ceil toint tofloat anytrue alltrue copy copyr",
+                    "op_type",
+                    "add"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "ret",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericRandom": {
+            "inputs": [
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "dim",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "symmetric",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "NumericRandomInt": {
+            "inputs": [
+                [
+                    "int",
+                    "min",
+                    "0"
+                ],
+                [
+                    "int",
+                    "max",
+                    "65536"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "NumericRangeList": {
+            "inputs": [
+                [
+                    "int",
+                    "start",
+                    "0"
+                ],
+                [
+                    "int",
+                    "end",
+                    "1"
+                ],
+                [
+                    "int",
+                    "skip",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "NumericVec2": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec2f",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericVec3": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "vec3",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericVec4": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec4f",
+                    "vec4",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "NumericWrangle": {
+            "inputs": [
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject:NumericObject",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "OSDPrimSubdiv": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "levels",
+                    "2"
+                ],
+                [
+                    "string",
+                    "edgeCreaseAttr",
+                    ""
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "asQuadFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "hasLoopUVs",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "delayTillIpc",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ObjTimeShift": {
+            "inputs": [
+                [
+                    "IObject",
+                    "obj",
+                    ""
+                ],
+                [
+                    "int",
+                    "offset",
+                    "1"
+                ],
+                [
+                    "ListObject",
+                    "customList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "IObject",
+                    "obj",
+                    ""
+                ],
+                [
+                    "IObject",
+                    "prevObj",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "OrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PackNumericIntVec2": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec2i",
+                    "vec2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PackNumericVec": {
+            "inputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum float vec2f vec3f vec4f",
+                    "type",
+                    "vec3f"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PackNumericVecInt": {
+            "inputs": [
+                [
+                    "int",
+                    "x",
+                    "0"
+                ],
+                [
+                    "int",
+                    "y",
+                    "0"
+                ],
+                [
+                    "int",
+                    "z",
+                    "0"
+                ],
+                [
+                    "int",
+                    "w",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum int vec2i vec3i vec4i",
+                    "type",
+                    "vec3i"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "veci",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "ParamFileParser": {
+            "inputs": [
+                [
+                    "",
+                    "formatList",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "configFilePath",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ParamFormat": {
+            "inputs": [
+                [
+                    "string",
+                    "name",
+                    ""
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i string",
+                    "type",
+                    "string"
+                ],
+                [
+                    "string",
+                    "defaultValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "format",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ParameterizeLine": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ParticleAsVoxels": {
+            "inputs": [
+                [
+                    "VDBGrid",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "Attr",
+                    ""
+                ],
+                [
+                    "",
+                    "particles",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "ParticleParticleWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticleToLevelSet": {
+            "inputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "float",
+                    "Radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "SurfaceSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ParticlesBuildBvh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "float",
+                    "radiusMin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesBuildHashGrid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "numeric:float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "numeric:float",
+                    "radiusMin",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "hashgrid",
+                    "hashGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesMaskedWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "string",
+                    "maskAttr",
+                    "mask"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborBvhWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "bool",
+                    "is_box",
+                    "1"
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborBvhWrangleSorted": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "bool",
+                    "is_box",
+                    "1"
+                ],
+                [
+                    "int",
+                    "limit",
+                    "-1"
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesNeighborWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "primNei",
+                    ""
+                ],
+                [
+                    "HashGrid",
+                    "hashGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ParticlesTwoWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ParticlesWrangle": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "PixarOrthonormalBase": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PlaneProjectPrimitive2DAABB": {
+            "inputs": [
+                [
+                    "",
+                    "origin",
+                    ""
+                ],
+                [
+                    "",
+                    "normal",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "",
+                    "bitangent",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "boundMin2D",
+                    ""
+                ],
+                [
+                    "",
+                    "boundMax2D",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "PolyDuplicate": {
+            "inputs": [
+                [
+                    "",
+                    "Mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Meshes",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PortalIn": {
+            "inputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "RenameMe!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "PortalOut": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "RenameMe!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "PrimAttrInterp": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    ""
+                ],
+                [
+                    "float",
+                    "factor",
+                    ""
+                ],
+                [
+                    "string",
+                    "facAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBarycentricInterp": {
+            "inputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "MeshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "triIdTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "weightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBend": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "midPoint",
+                    ""
+                ],
+                [
+                    "float",
+                    "biasDir",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimBoundingBox": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "extraBound",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "center",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "diameter",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCalcCentroid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum Volume Area Vertex BoundBox",
+                    "method",
+                    "Volume"
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "centroid",
+                    ""
+                ],
+                [
+                    "float",
+                    "mass",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCheckTagInRange": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "index"
+                ],
+                [
+                    "int",
+                    "beg",
+                    "0"
+                ],
+                [
+                    "int",
+                    "end",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "endExcluded",
+                    "0"
+                ],
+                [
+                    "int",
+                    "modularBy",
+                    "0"
+                ],
+                [
+                    "int",
+                    "trueVal",
+                    "1"
+                ],
+                [
+                    "int",
+                    "falseVal",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimColorByTag": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "clrAttr",
+                    "clr"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "PrimConnectBridge": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "edgeIndAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimConnectSkin": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isCloseRing",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimConnectTape": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "enum quads lines none",
+                    "faceType",
+                    "quads"
+                ],
+                [
+                    "bool",
+                    "isCloseRing",
+                    "0"
+                ],
+                [
+                    "string",
+                    "edgeMaskAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimCopyFloatAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "sourceName",
+                    "s"
+                ],
+                [
+                    "string",
+                    "targetName",
+                    "t"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDecodeUVs": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimDualMesh": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "polygonate",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "keepBounds",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDuplicate": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "tanAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "radAttr",
+                    ""
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "copyParsAttr",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "copyMeshAttr",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimDuplicateConnLines": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "tanAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "radAttr",
+                    ""
+                ],
+                [
+                    "enum XYZ YXZ YZX ZYX ZXY XZY",
+                    "onbType",
+                    "XYZ"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "copyParsAttr",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "copyMeshAttr",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimEdgeBound": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "killDeadVerts",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimExtrude": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "maskAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "extrude",
+                    ""
+                ],
+                [
+                    "float",
+                    "inset",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "string",
+                    "sourceMaskAttrO",
+                    ""
+                ],
+                [
+                    "bool",
+                    "delOldFaces",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "autoFindEdges",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "averagedExtrude",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "flipOldFaces",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFacesAttrToVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum lines tris quads polys",
+                    "faceType",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "faceAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "vertAttr",
+                    "tmp"
+                ],
+                [
+                    "float",
+                    "deflVal",
+                    ""
+                ],
+                [
+                    "enum sum average min max",
+                    "method",
+                    "average"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFacesCenterAsVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum faces lines",
+                    "faceType",
+                    "faces"
+                ],
+                [
+                    "bool",
+                    "copyFaceAttrs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFillAttr": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "rad"
+                ],
+                [
+                    "enum float vec3f int",
+                    "type",
+                    "float"
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFillColor": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFilter": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "revampAttrO",
+                    ""
+                ],
+                [
+                    "int",
+                    "tagValue",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "isInversed",
+                    "1"
+                ],
+                [
+                    "enum verts faces",
+                    "method",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFlattenTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFlipFaces": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimFloatAttrToInt": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "tag"
+                ],
+                [
+                    "float",
+                    "divisor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimForceTrail": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "trailPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "forceAttr",
+                    "force"
+                ],
+                [
+                    "float",
+                    "attractForce",
+                    ""
+                ],
+                [
+                    "float",
+                    "driftForce",
+                    ""
+                ],
+                [
+                    "",
+                    "attractUDFCurve",
+                    ""
+                ],
+                [
+                    "",
+                    "driftCoordCurve",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimGenerateONB": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    "nrm"
+                ],
+                [
+                    "string",
+                    "tanAttrOut",
+                    "tang"
+                ],
+                [
+                    "string",
+                    "bitanAttrOut",
+                    "bitang"
+                ],
+                [
+                    "bool",
+                    "writebackDir",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimGetAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "index"
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i",
+                    "type",
+                    "int"
+                ],
+                [
+                    "enum vert tri",
+                    "method",
+                    "tri"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimGetTrisSize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "int",
+                    "TrisSize",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimIntAttrToFloat": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tag"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "tag"
+                ],
+                [
+                    "float",
+                    "divisor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimKillDeadVerts": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimLineGenerateONB": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "dirAttrOut",
+                    "dir"
+                ],
+                [
+                    "string",
+                    "tanAttrOut",
+                    "tang"
+                ],
+                [
+                    "string",
+                    "bitanAttrOut",
+                    "bitang"
+                ],
+                [
+                    "bool",
+                    "lineSort",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimLoopUVsToVerts": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkClose": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "distance",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "weld"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkIndex": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "index"
+                ],
+                [
+                    "enum int float",
+                    "type",
+                    "int"
+                ],
+                [
+                    "int",
+                    "base",
+                    "0"
+                ],
+                [
+                    "int",
+                    "step",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkIsland": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkSameIf": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttrIn",
+                    "index"
+                ],
+                [
+                    "int",
+                    "tagValueIs",
+                    "0"
+                ],
+                [
+                    "string",
+                    "tagAttrOut",
+                    "weld"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMarkTrisIdx": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "idxName",
+                    "index"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimMatchUVLine": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "string",
+                    "uvAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "uvAttr2",
+                    "tmp"
+                ],
+                [
+                    "bool",
+                    "copyOtherAttrs",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimMerge": {
+            "inputs": [
+                [
+                    "list",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimPerlinNoise": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "inAttr",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "outAttr",
+                    "tmp"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "detail",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "disortion",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "average",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "enum float vec3f",
+                    "outType",
+                    "float"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimPointTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "pointID",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimProject": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "limit",
+                    ""
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimQuadsLotSubdivision": {
+            "inputs": [
+                [
+                    "",
+                    "input_quads_model",
+                    ""
+                ],
+                [
+                    "int",
+                    "num",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "row_or_columns",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "random_rc",
+                    "0"
+                ],
+                [
+                    "int",
+                    "random_seed",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "rcrc",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "first_second_same",
+                    "1"
+                ],
+                [
+                    "int",
+                    "same_seed",
+                    "1"
+                ],
+                [
+                    "float",
+                    "min_offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "first_edge_minoffset",
+                    ""
+                ],
+                [
+                    "float",
+                    "first_edge_maxoffset",
+                    ""
+                ],
+                [
+                    "int",
+                    "first_seed",
+                    "1"
+                ],
+                [
+                    "float",
+                    "second_edge_minoffset",
+                    ""
+                ],
+                [
+                    "float",
+                    "second_edge_maxoffset",
+                    ""
+                ],
+                [
+                    "int",
+                    "second_seed",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "add_attr",
+                    "0"
+                ],
+                [
+                    "string",
+                    "tag_attr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimRandomize": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "dirAttr",
+                    ""
+                ],
+                [
+                    "string",
+                    "seedAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum scalar01 scalar11 cube01 cube11 plane01 plane11 disk cylinder ball semiball sphere semisphere",
+                    "randType",
+                    "scalar01"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "sampledObject",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "uv"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "enum REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrap",
+                    "REPEAT"
+                ],
+                [
+                    "vec3f",
+                    "borderColor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample1D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "rho"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample2D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "string",
+                    "uvChannel",
+                    "uv"
+                ],
+                [
+                    "string",
+                    "targetChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "enum REPEAT CLAMP_TO_EDGE CLAMP_TO_BORDER",
+                    "wrap",
+                    "REPEAT"
+                ],
+                [
+                    "vec3f",
+                    "borderColor",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSample3D": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "srcChannel",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "dstChannel",
+                    "clr"
+                ],
+                [
+                    "float",
+                    "remapMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "remapMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimScale": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimScatter": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum tris lines",
+                    "type",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "denAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "float",
+                    "minRadius",
+                    ""
+                ],
+                [
+                    "bool",
+                    "interpAttrs",
+                    "1"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSepTriangles": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "smoothNormal",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "keepTriFaces",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSetAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "value",
+                    "0"
+                ],
+                [
+                    "string",
+                    "name",
+                    "index"
+                ],
+                [
+                    "enum float vec2f vec3f vec4f int vec2i vec3i vec4i",
+                    "type",
+                    "int"
+                ],
+                [
+                    "enum vert tri",
+                    "method",
+                    "tri"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimSimplifyTag": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSmooth": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSplit": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSprayParticles": {
+            "inputs": [
+                [
+                    "",
+                    "TrianglePrim",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimSuperFormula": {
+            "inputs": [
+                [
+                    "int",
+                    "segments",
+                    "1000"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "a",
+                    ""
+                ],
+                [
+                    "float",
+                    "b",
+                    ""
+                ],
+                [
+                    "float",
+                    "m",
+                    ""
+                ],
+                [
+                    "float",
+                    "n1",
+                    ""
+                ],
+                [
+                    "float",
+                    "n2",
+                    ""
+                ],
+                [
+                    "float",
+                    "n3",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasLines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "close",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimToList": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads polys loops",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimToVDBPointDataGrid": {
+            "inputs": [
+                [
+                    "",
+                    "ParticleGeo",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbPoints",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "PrimTranslate": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimTriPoints": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "trisID",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "PrimTwist": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimUnmerge": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "tag"
+                ],
+                [
+                    "bool",
+                    "preSimplify",
+                    "0"
+                ],
+                [
+                    "enum verts faces",
+                    "method",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "list",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimUpdateFromList": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads polys loops",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimVertsAttrToFaces": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum lines tris quads polys",
+                    "faceType",
+                    "tris"
+                ],
+                [
+                    "string",
+                    "vertAttr",
+                    "tmp"
+                ],
+                [
+                    "string",
+                    "faceAttr",
+                    "tmp"
+                ],
+                [
+                    "enum sum average min max",
+                    "method",
+                    "average"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimWeld": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "tagAttr",
+                    "weld"
+                ],
+                [
+                    "enum oneof average",
+                    "method",
+                    "oneof"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimWireframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveAddAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "fillValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "clr"
+                ],
+                [
+                    "string",
+                    "pybisgreat",
+                    "DEPRECATED! USE PrimFillAttr INSTEAD"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveAttrFit": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "refPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrNameSrc",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrNameDst",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "refAttrNameSrc",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "refAttrNameDst",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "enum X Y Z",
+                    "axisSrc",
+                    "X"
+                ],
+                [
+                    "enum X Y Z",
+                    "axisDst",
+                    "Y"
+                ],
+                [
+                    "enum X Y Z",
+                    "refAxisSrc",
+                    "X"
+                ],
+                [
+                    "enum X Y Z",
+                    "refAxisDst",
+                    "Y"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "autoMinMax",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "autoSort",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveAttrPicker": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum point line triangle",
+                    "mode",
+                    "point"
+                ],
+                [
+                    "string",
+                    "newAttr",
+                    ""
+                ],
+                [
+                    "float",
+                    "attrVal",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "selected",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveBent": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "midPoint",
+                    ""
+                ],
+                [
+                    "float",
+                    "biasDir",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "useOrigin",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveBinaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrB",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copyA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveBooleanOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "faceAttrA",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "faceAttrB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "calcAnyFrom",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix",
+                    "0"
+                ],
+                [
+                    "string",
+                    "faceAttrName",
+                    ""
+                ],
+                [
+                    "enum Union Intersect Minus RevMinus XOR Resolve",
+                    "op_type",
+                    "Union"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primC",
+                    ""
+                ],
+                [
+                    "bool",
+                    "anyFromA",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "anyFromB",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveBoundingBox": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "exWidth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveCalcCentroid": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Volume Area Vertex",
+                    "method",
+                    "Volume"
+                ]
+            ],
+            "outputs": [
+                [
+                    "vec3f",
+                    "centroid",
+                    ""
+                ],
+                [
+                    "float",
+                    "totalArea",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveCalcNormal": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "bool",
+                    "flip",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveCalcVelocity": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveClearConnect": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum edges faces tris quads polys points all",
+                    "type",
+                    "all"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveClip": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "distance",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "reverse",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveColorByHeatmap": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "heatmap",
+                    ""
+                ],
+                [
+                    "float",
+                    "min",
+                    ""
+                ],
+                [
+                    "float",
+                    "max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "rho"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveConvexDecomposition": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveConvexDecompositionV": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveCurvemap": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "curvemap",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "int",
+                    "sourceX",
+                    "0"
+                ],
+                [
+                    "int",
+                    "sourceY",
+                    "1"
+                ],
+                [
+                    "int",
+                    "sourceZ",
+                    "2"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveDelAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "nrm"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveDuplicate": {
+            "inputs": [
+                [
+                    "",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "float",
+                    "uniScale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "attrFromMesh",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "attrFromParticles",
+                    "1"
+                ],
+                [
+                    "string",
+                    "scaleByAttr",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFaceToEdges": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "clearFaces",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFarSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveFillAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3 none",
+                    "attrType",
+                    "none"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveFilterByAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum cmpgt cmplt cmpge cmple cmpeq cmpne",
+                    "acceptIf",
+                    "cmpgt"
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "rad"
+                ],
+                [
+                    "bool",
+                    "mockTopos",
+                    "1"
+                ],
+                [
+                    "enum any all",
+                    "vecSelType",
+                    "all"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveFlipPoly": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveGetAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveGetFaceCount": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveGetSize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveHalfBinaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "valueB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copyA"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveInterpSubframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "portion",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineDistance": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "resAttr",
+                    "len"
+                ],
+                [
+                    "int",
+                    "start",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSimpleLink": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSolidify": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "4"
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "string",
+                    "radiusAttr",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isTri",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "sealEnd",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "closeRing",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "lineSort",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveLineSort": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "reversed",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveListBoolOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primListB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    ""
+                ],
+                [
+                    "bool",
+                    "assignAttrs",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "calcAnyFrom",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix",
+                    "1"
+                ],
+                [
+                    "string",
+                    "faceAttrName",
+                    ""
+                ],
+                [
+                    "bool",
+                    "noNullMesh",
+                    "1"
+                ],
+                [
+                    "enum Union Intersect Minus RevMinus XOR Resolve",
+                    "op_type",
+                    "Union"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "lutList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveMerge": {
+            "inputs": [
+                [
+                    "",
+                    "listPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveMeshingFix": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primFixed",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "PrimitiveMix": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primB",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "coef",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrB",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveNearSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitivePerlinNoiseAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "freq",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "noise"
+            ]
+        },
+        "PrimitivePolygonate": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "with_uv",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitivePrintAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveRandomAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "min",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveRandomizeAttr": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float3"
+                ],
+                [
+                    "float",
+                    "max",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxY",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxZ",
+                    ""
+                ],
+                [
+                    "float",
+                    "min",
+                    ""
+                ],
+                [
+                    "float",
+                    "minY",
+                    ""
+                ],
+                [
+                    "float",
+                    "minZ",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveReduction": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "enum avg max min absmax",
+                    "op",
+                    "avg"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveResize": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveScale": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "axis",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveScatter": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "npoints",
+                    "100"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum tris lines",
+                    "type",
+                    "tris"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSetAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "pos"
+                ],
+                [
+                    "enum float float3",
+                    "type",
+                    "float3"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleLines": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimplePoints": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleQuads": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSimpleTris": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveSplitEdges": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToBulletMesh": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Bullet"
+            ]
+        },
+        "PrimitiveToMesh": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToParticles": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveToSDF": {
+            "inputs": [
+                [
+                    "",
+                    "PrimitiveMesh",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum vertex cell",
+                    "type",
+                    "vertex"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "sdf",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "PrimitiveTraceTrail": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "parsPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "trailPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTransform": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "enum world bboxCenter",
+                    "pivot",
+                    "world"
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "eulerXYZ",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shear",
+                    ""
+                ],
+                [
+                    "",
+                    "Matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "preTransform",
+                    ""
+                ],
+                [
+                    "",
+                    "local",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTriangulate": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "from_poly",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "from_quads",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "has_lines",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "with_uv",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrimitiveTwist": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "",
+                    "tangent",
+                    ""
+                ],
+                [
+                    "float",
+                    "angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "limitMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveUnaryOp": {
+            "inputs": [
+                [
+                    "",
+                    "primA",
+                    ""
+                ],
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrA",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "attrOut",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "op",
+                    "copy"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveVoronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "int",
+                    "numParticles",
+                    "64"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    "use VoronoiFracture instead!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primList",
+                    ""
+                ],
+                [
+                    "",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrimitiveWireframe": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "removeFaces",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "PrintMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello-stdout"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "PrintMessageStdErr": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello-stderr"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "PrintNumeric": {
+            "inputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "hint",
+                    "PrintNumeric"
+                ]
+            ],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "PrintPrimInfo": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "printInfo",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "PrintString": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "ProceduralSky": {
+            "inputs": [
+                [
+                    "vec2f",
+                    "sunLightDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "sunLightSoftness",
+                    ""
+                ],
+                [
+                    "float",
+                    "sunLightIntensity",
+                    ""
+                ],
+                [
+                    "float",
+                    "colorTemperatureMix",
+                    ""
+                ],
+                [
+                    "float",
+                    "colorTemperature",
+                    ""
+                ],
+                [
+                    "vec2f",
+                    "windDir",
+                    ""
+                ],
+                [
+                    "float",
+                    "timeStart",
+                    ""
+                ],
+                [
+                    "float",
+                    "timeSpeed",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "ProceduralSky",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ProjectAndNormalize": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "enum XY YX YZ ZY ZX XZ",
+                    "plane",
+                    "XY"
+                ],
+                [
+                    "float",
+                    "directionScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "lengthScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "heightScale",
+                    ""
+                ],
+                [
+                    "float",
+                    "heightOffset",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec3f",
+                    "direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "length",
+                    ""
+                ],
+                [
+                    "float",
+                    "height",
+                    ""
+                ],
+                [
+                    "float",
+                    "phase",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "QuatRotBetweenVectors": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "start",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "dest",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "QueryNearestPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "string",
+                    "idTag",
+                    "bvh_id"
+                ],
+                [
+                    "string",
+                    "distTag",
+                    "bvh_dist"
+                ],
+                [
+                    "string",
+                    "closestPointTag",
+                    "cp"
+                ],
+                [
+                    "string",
+                    "weightTag",
+                    "bvh_ws"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "NumericObject",
+                    "primid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "bvh_primid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "dist",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "bvh_prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "segment",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "RadtoDegree": {
+            "inputs": [
+                [
+                    "float",
+                    "radian",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "degree",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "RandomParticles": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "Prange",
+                    ""
+                ],
+                [
+                    "float",
+                    "Vrange",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "1 0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadAudioFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "audio"
+            ]
+        },
+        "ReadCustomVAT": {
+            "inputs": [
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadFBXPrim": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "bool",
+                    "generate",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "invOpacity",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "primitive",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "printTree",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "triangulate",
+                    "0"
+                ],
+                [
+                    "enum ENABLE DISABLE",
+                    "udim",
+                    "DISABLE"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "prims",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "datas",
+                    ""
+                ],
+                [
+                    "",
+                    "mats",
+                    ""
+                ],
+                [
+                    "",
+                    "animinfo",
+                    ""
+                ],
+                [
+                    "",
+                    "nodetree",
+                    ""
+                ],
+                [
+                    "",
+                    "bonetree",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ReadImageFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadLightFromFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "posList",
+                    ""
+                ],
+                [
+                    "",
+                    "rotList",
+                    ""
+                ],
+                [
+                    "",
+                    "sclList",
+                    ""
+                ],
+                [
+                    "",
+                    "colList",
+                    ""
+                ],
+                [
+                    "",
+                    "intList",
+                    ""
+                ],
+                [
+                    "",
+                    "expList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "FBX"
+            ]
+        },
+        "ReadMp3File": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjPrim": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "triangulate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadObjPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadObjPrimitiveDict": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadParticles": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadPlyPrimitive": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadVATFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "image",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ReadVDB": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum float float3 int int3 points",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ReadVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ReadWavFile": {
+            "inputs": [
+                [
+                    "readpath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "wave",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "RefitPrimitiveBvh": {
+            "inputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "LBvh",
+                    "lbvh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "ResampleVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "resampleTo",
+                    ""
+                ],
+                [
+                    "",
+                    "resampleFrom",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "resampleTo",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ResizeList": {
+            "inputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "int",
+                    "newSize",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "list"
+            ]
+        },
+        "RobotGetJointName": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotGetLinkName": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "index",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotLoadURDF": {
+            "inputs": [
+                [
+                    "",
+                    "path",
+                    ""
+                ],
+                [
+                    "float",
+                    "globalScaling",
+                    ""
+                ],
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum true false",
+                    "fixedBase",
+                    "true"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "world",
+                    ""
+                ],
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "visualMap",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "RobotSetJointPoses": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "qDesiredList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Robot"
+            ]
+        },
+        "Route": {
+            "inputs": [
+                [
+                    "",
+                    "input",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "output",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "SDFAdvect": {
+            "inputs": [
+                [
+                    "",
+                    "InoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "VecField",
+                    ""
+                ],
+                [
+                    "float",
+                    "TimeStep",
+                    ""
+                ],
+                [
+                    "enum Order_1 Order_2 Order_3 Order_5_WENO Order_5_HJ_WENO",
+                    "SpatialScheme",
+                    "Order_5_HJ_WENO"
+                ],
+                [
+                    "enum Explicit_Euler Order_2_Runge_Kuta Order_3_Runge_Kuta",
+                    "TemporalScheme",
+                    "Order_2_Runge_Kuta"
+                ],
+                [
+                    "int",
+                    "RenormalizeStep",
+                    "3"
+                ],
+                [
+                    "enum Order_1 Order_2 Order_3 Order_5_WENO Order_5_HJ_WENO",
+                    "TrackerSpatialScheme",
+                    "Order_5_HJ_WENO"
+                ],
+                [
+                    "enum Explicit_Euler Order_2_Runge_Kuta Order_3_Runge_Kuta",
+                    "TrackerTemporalScheme",
+                    "Explicit_Euler"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "InoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFScatterPoints": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "Points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToFog": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "bool",
+                    "inplace",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToPoly": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "Mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SDFToPrim": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ],
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SDFToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "SDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "adaptivity",
+                    ""
+                ],
+                [
+                    "bool",
+                    "allowQuads",
+                    "0"
+                ],
+                [
+                    "float",
+                    "isoValue",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SampleVDBToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "sampleBy",
+                    "pos"
+                ],
+                [
+                    "string",
+                    "primAttr",
+                    "sdf"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Clamp Periodic",
+                    "SampleType",
+                    "Clamp"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "ScalarFieldAnalyzer": {
+            "inputs": [
+                [
+                    "",
+                    "InVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Gradient Curvature Laplacian ClosestPoint",
+                    "Operator",
+                    "Gradient"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "OutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SetFrameTime": {
+            "inputs": [
+                [
+                    "",
+                    "time",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "frame"
+            ]
+        },
+        "SetInstancing": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "instancing",
+                    "inst",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "SetMaterial": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "material",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SetMatrix": {
+            "inputs": [
+                [
+                    "",
+                    "dst",
+                    ""
+                ],
+                [
+                    "",
+                    "src",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "SetRandomSeed": {
+            "inputs": [
+                [
+                    "",
+                    "routeIn",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "routeOut",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SetUserData": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "key",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "lifecycle"
+            ]
+        },
+        "SetVDBGridName": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "density"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "SetVDBPointDataGrid": {
+            "inputs": [
+                [
+                    "",
+                    "ParticleGeo",
+                    ""
+                ],
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "dx",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "Particles",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ShaderBinaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "float",
+                    "in2",
+                    ""
+                ],
+                [
+                    "enum add sub mul div mod pow atan2 min max dot cross distance",
+                    "op",
+                    "add"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderBlendMode": {
+            "inputs": [
+                [
+                    "float",
+                    "base",
+                    ""
+                ],
+                [
+                    "float",
+                    "blend",
+                    ""
+                ],
+                [
+                    "float",
+                    "opacity",
+                    ""
+                ],
+                [
+                    "enum add average colorBurn colorDodge darken difference exclusion glow hardLight hardMix lighten linearBurn linearDodge linearLight multiply negation normal overlay phoenix pinLight reflect screen softLight subtract vividLight",
+                    "mode",
+                    "normal"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderCihouUnrealEngine": {
+            "inputs": [
+                [
+                    "MaterialObject",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "code",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderCustomFunc": {
+            "inputs": [
+                [
+                    "string",
+                    "args",
+                    "vec3 arg1, vec3 arg2"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "rettype",
+                    "vec3"
+                ],
+                [
+                    "string",
+                    "code",
+                    "return arg1 + arg2;"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ShaderCustomFuncObject",
+                    "func",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderExtractVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderFillVec": {
+            "inputs": [
+                [
+                    "float",
+                    "in",
+                    ""
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderFinalize": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "basecolor",
+                    ""
+                ],
+                [
+                    "float",
+                    "metallic",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "specular",
+                    ""
+                ],
+                [
+                    "float",
+                    "subsurface",
+                    ""
+                ],
+                [
+                    "float",
+                    "thickness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sssParam",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "sssColor",
+                    ""
+                ],
+                [
+                    "float",
+                    "foliage",
+                    ""
+                ],
+                [
+                    "float",
+                    "skin",
+                    ""
+                ],
+                [
+                    "float",
+                    "curvature",
+                    ""
+                ],
+                [
+                    "float",
+                    "specularTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "anisotropic",
+                    ""
+                ],
+                [
+                    "float",
+                    "anisoRotation",
+                    ""
+                ],
+                [
+                    "float",
+                    "sheen",
+                    ""
+                ],
+                [
+                    "float",
+                    "sheenTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "clearcoat",
+                    ""
+                ],
+                [
+                    "float",
+                    "clearcoatGloss",
+                    ""
+                ],
+                [
+                    "float",
+                    "specTrans",
+                    ""
+                ],
+                [
+                    "float",
+                    "ior",
+                    ""
+                ],
+                [
+                    "float",
+                    "flatness",
+                    ""
+                ],
+                [
+                    "float",
+                    "scatterDistance",
+                    ""
+                ],
+                [
+                    "float",
+                    "scatterStep",
+                    ""
+                ],
+                [
+                    "float",
+                    "thin",
+                    ""
+                ],
+                [
+                    "float",
+                    "doubleSide",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "normal",
+                    ""
+                ],
+                [
+                    "float",
+                    "displacement",
+                    ""
+                ],
+                [
+                    "float",
+                    "smoothness",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "emission",
+                    ""
+                ],
+                [
+                    "float",
+                    "exposure",
+                    ""
+                ],
+                [
+                    "float",
+                    "ao",
+                    ""
+                ],
+                [
+                    "float",
+                    "toon",
+                    ""
+                ],
+                [
+                    "float",
+                    "stroke",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shape",
+                    ""
+                ],
+                [
+                    "float",
+                    "style",
+                    ""
+                ],
+                [
+                    "float",
+                    "strokeNoise",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shad",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "strokeTint",
+                    ""
+                ],
+                [
+                    "float",
+                    "opacity",
+                    ""
+                ],
+                [
+                    "float",
+                    "reflection",
+                    ""
+                ],
+                [
+                    "float",
+                    "reflectID",
+                    ""
+                ],
+                [
+                    "float",
+                    "isCamera",
+                    ""
+                ],
+                [
+                    "float",
+                    "isVoxelDomain",
+                    ""
+                ],
+                [
+                    "string",
+                    "commonCode",
+                    ""
+                ],
+                [
+                    "string",
+                    "extensionsCode",
+                    ""
+                ],
+                [
+                    "string",
+                    "mtlid",
+                    "Mat1"
+                ],
+                [
+                    "list",
+                    "tex2dList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum GLSL HLSL",
+                    "backend",
+                    "GLSL"
+                ]
+            ],
+            "outputs": [
+                [
+                    "MaterialObject",
+                    "mtl",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderInputAttr": {
+            "inputs": [
+                [
+                    "enum pos clr nrm uv tang bitang NoL instPos instNrm instUv instClr instTang",
+                    "attr",
+                    "pos"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderInvokeFunc": {
+            "inputs": [
+                [
+                    "ShaderCustomFuncObject",
+                    "func",
+                    ""
+                ],
+                [
+                    "list",
+                    "args",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderLinearFit": {
+            "inputs": [
+                [
+                    "float",
+                    "in",
+                    ""
+                ],
+                [
+                    "float",
+                    "inMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "inMax",
+                    ""
+                ],
+                [
+                    "float",
+                    "outMin",
+                    ""
+                ],
+                [
+                    "float",
+                    "outMax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "clamped",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderMakeVec": {
+            "inputs": [
+                [
+                    "float",
+                    "x",
+                    ""
+                ],
+                [
+                    "float",
+                    "y",
+                    ""
+                ],
+                [
+                    "float",
+                    "z",
+                    ""
+                ],
+                [
+                    "float",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderPackVec": {
+            "inputs": [
+                [
+                    "shader",
+                    "x",
+                    ""
+                ],
+                [
+                    "shader",
+                    "y",
+                    ""
+                ],
+                [
+                    "shader",
+                    "z",
+                    ""
+                ],
+                [
+                    "shader",
+                    "w",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "vec4f",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderReduceVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "in",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum average sum",
+                    "op",
+                    "average"
+                ]
+            ],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderTernaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "float",
+                    "in2",
+                    ""
+                ],
+                [
+                    "float",
+                    "in3",
+                    ""
+                ],
+                [
+                    "enum mix clamp smoothstep add3",
+                    "op",
+                    "mix"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderTexture2D": {
+            "inputs": [
+                [
+                    "int",
+                    "texId",
+                    "0"
+                ],
+                [
+                    "vec2f",
+                    "coord",
+                    ""
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderUnaryMath": {
+            "inputs": [
+                [
+                    "float",
+                    "in1",
+                    ""
+                ],
+                [
+                    "enum copy neg abs sqrt inversesqrt exp log sin cos tan asin acos atan degrees radians sinh cosh tanh asinh acosh atanh round roundEven floor ceil trunc sign step length normalize",
+                    "op",
+                    "sqrt"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "ShaderUniformAttr": {
+            "inputs": [
+                [
+                    "int",
+                    "idx",
+                    "0"
+                ],
+                [
+                    "enum float vec2 vec3 vec4",
+                    "type",
+                    "vec3"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "shader",
+                    "out",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "shader"
+            ]
+        },
+        "SimplifyVoroNeighborList": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "ListObject",
+                    "newNeighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "SolveNonlinearProblem2": {
+            "inputs": [
+                [
+                    "",
+                    "JFNKSolverObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "NonlinearProblemObject2",
+                    ""
+                ],
+                [
+                    "",
+                    "function",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "Zentricle"
+            ]
+        },
+        "SpdlogErrorMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "error from spdlog!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "SpdlogInfoMessage": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "hello from spdlog!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "StringEqual": {
+            "inputs": [
+                [
+                    "string",
+                    "lhs",
+                    ""
+                ],
+                [
+                    "string",
+                    "rhs",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "bool",
+                    "isEqual",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "StringEval": {
+            "inputs": [
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "result",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "StringFormat": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringFormatNumStr": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "{}"
+                ],
+                [
+                    "",
+                    "num_str",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "StringFormatNumber": {
+            "inputs": [
+                [
+                    "string",
+                    "str",
+                    "{}"
+                ],
+                [
+                    "",
+                    "number",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "string",
+                    "str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringToMesh": {
+            "inputs": [
+                [
+                    "",
+                    "string",
+                    ""
+                ],
+                [
+                    "",
+                    "AZmesh",
+                    ""
+                ],
+                [
+                    "",
+                    "spacing",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "StringMeshList",
+                    ""
+                ],
+                [
+                    "",
+                    "SpacingList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "StringToNumber": {
+            "inputs": [
+                [
+                    "enum float int",
+                    "type",
+                    "all"
+                ],
+                [
+                    "string",
+                    "str",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "num_str",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "string"
+            ]
+        },
+        "SubCategory": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "name",
+                    "subgraph"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubInput": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "defl",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "input1"
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "bool",
+                    "hasValue",
+                    "0"
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubLine": {
+            "inputs": [
+                [
+                    "",
+                    "line",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "value",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum cmpgt cmplt cmpge cmple cmpeq cmpne",
+                    "acceptIf",
+                    "cmpgt"
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "rad"
+                ],
+                [
+                    "enum any all",
+                    "vecSelType",
+                    "all"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "SubOutput": {
+            "inputs": [
+                [
+                    "",
+                    "port",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "defl",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "output1"
+                ],
+                [
+                    "string",
+                    "type",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "subgraph"
+            ]
+        },
+        "SubstepDt": {
+            "inputs": [
+                [
+                    "",
+                    "FOR",
+                    ""
+                ],
+                [
+                    "float",
+                    "desired_dt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "actual_dt",
+                    ""
+                ],
+                [
+                    "float",
+                    "portion",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "control"
+            ]
+        },
+        "SyncPrimitiveAttributes": {
+            "inputs": [
+                [
+                    "",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim1",
+                    ""
+                ],
+                [
+                    "",
+                    "prim2",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "TestRayBox": {
+            "inputs": [
+                [
+                    "",
+                    "ray_origin",
+                    ""
+                ],
+                [
+                    "",
+                    "ray_dir",
+                    ""
+                ],
+                [
+                    "",
+                    "box_min",
+                    ""
+                ],
+                [
+                    "",
+                    "box_max",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "predicate",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "ToView": {
+            "inputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "bool",
+                    "isStatic",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "object",
+                    ""
+                ],
+                [
+                    "string",
+                    "viewid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "layout"
+            ]
+        },
+        "TraceOneStep": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "dt",
+                    ""
+                ],
+                [
+                    "",
+                    "size",
+                    ""
+                ],
+                [
+                    "",
+                    "steps",
+                    ""
+                ],
+                [
+                    "",
+                    "maxlength",
+                    ""
+                ],
+                [
+                    "",
+                    "vecField",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "TracePositionOneStep": {
+            "inputs": [
+                [
+                    "",
+                    "primData",
+                    ""
+                ],
+                [
+                    "",
+                    "primStart",
+                    ""
+                ],
+                [
+                    "string",
+                    "lineTag",
+                    "lineID"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primVis",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "TransformMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "translate",
+                    ""
+                ],
+                [
+                    "",
+                    "rotate",
+                    ""
+                ],
+                [
+                    "",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "TransformPrimitive": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "eulerXYZ",
+                    ""
+                ],
+                [
+                    "vec4f",
+                    "quatRotation",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "shear",
+                    ""
+                ],
+                [
+                    "",
+                    "Matrix",
+                    ""
+                ],
+                [
+                    "",
+                    "preTransform",
+                    ""
+                ],
+                [
+                    "",
+                    "local",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "TriggerAbortSignal": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerDivideZero": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerException": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "message",
+                    "exception occurred!"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerExitProcess": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "status",
+                    "-1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerSegFault": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "TriggerViewportFault": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "debug"
+            ]
+        },
+        "UVProjectFromPlane": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "refPlane",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "UnpackNumericVec": {
+            "inputs": [
+                [
+                    "vec3f",
+                    "vec",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "X",
+                    ""
+                ],
+                [
+                    "float",
+                    "Y",
+                    ""
+                ],
+                [
+                    "float",
+                    "Z",
+                    ""
+                ],
+                [
+                    "float",
+                    "W",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "numeric"
+            ]
+        },
+        "UpdateCurveControlPoint": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "int",
+                    "index",
+                    "0"
+                ],
+                [
+                    "optional float",
+                    "point_x",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "point_y",
+                    ""
+                ],
+                [
+                    "optional vec2f",
+                    "left_handler",
+                    ""
+                ],
+                [
+                    "optional vec2f",
+                    "right_handler",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "UpdateCurveCycleType": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "enum CLAMP CYCLE MIRROR",
+                    "type",
+                    "CLAMP"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "UpdateCurveXYRange": {
+            "inputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "string",
+                    "key",
+                    "x"
+                ],
+                [
+                    "optional float",
+                    "x_from",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "x_to",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "y_from",
+                    ""
+                ],
+                [
+                    "optional float",
+                    "y_to",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "curve",
+                    "curve",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "curve"
+            ]
+        },
+        "VDBAddPerlinNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "VDBAddTurbulentNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBChangeBackground": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBCreateLevelsetSphere": {
+            "inputs": [
+                [
+                    "float",
+                    "Dx",
+                    ""
+                ],
+                [
+                    "float",
+                    "radius",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "center",
+                    ""
+                ],
+                [
+                    "float",
+                    "half_width",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBDeactivate": {
+            "inputs": [
+                [
+                    "",
+                    "Field",
+                    ""
+                ],
+                [
+                    "",
+                    "Mask",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBDilateTopo": {
+            "inputs": [
+                [
+                    "",
+                    "inField",
+                    ""
+                ],
+                [
+                    "int",
+                    "layers",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "oField",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBErodeSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "depth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBExplosiveTurbulentNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scaling",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "translation",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "float",
+                    "FBM_EvalPersist",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_Lacunarity",
+                    ""
+                ],
+                [
+                    "int",
+                    "FBM_Octaves",
+                    "5"
+                ],
+                [
+                    "float",
+                    "FBM_Persistence",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpPersist",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpPrimary",
+                    ""
+                ],
+                [
+                    "float",
+                    "FBM_WarpSecond",
+                    ""
+                ],
+                [
+                    "float",
+                    "Speed",
+                    ""
+                ],
+                [
+                    "float",
+                    "UVScale",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBFillActiveVoxels": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "NumericObject",
+                    "fillValue",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBGetBackground": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "float",
+                    "background",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBInvertSDF": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBLeafAsParticles": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primPars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VDBPerlinNoise": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "scale3d",
+                    ""
+                ],
+                [
+                    "float",
+                    "detail",
+                    ""
+                ],
+                [
+                    "float",
+                    "roughness",
+                    ""
+                ],
+                [
+                    "float",
+                    "disortion",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "average",
+                    ""
+                ],
+                [
+                    "float",
+                    "strength",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPointScatter": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "int",
+                    "count",
+                    "4"
+                ],
+                [
+                    "float",
+                    "spread",
+                    ""
+                ],
+                [
+                    "int",
+                    "seed",
+                    "-1"
+                ],
+                [
+                    "enum Fog SDF",
+                    "gridtype",
+                    "Fog"
+                ],
+                [
+                    "enum PerVoxel Total",
+                    "counttype",
+                    "PerVoxel"
+                ],
+                [
+                    "enum Uniform NonUniform",
+                    "method",
+                    "Uniform"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "points",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPointsToPrimitive": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBPruneFootprint": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBRenormalizeSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "dilateIters",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "4"
+                ],
+                [
+                    "enum 1oUpwind",
+                    "method",
+                    "1oUpwind"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBSmooth": {
+            "inputs": [
+                [
+                    "",
+                    "inoutVDB",
+                    ""
+                ],
+                [
+                    "enum Mean Gaussian Median",
+                    "type",
+                    "Gaussian"
+                ],
+                [
+                    "int",
+                    "width",
+                    "1"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "inoutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBSmoothSDF": {
+            "inputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "DEPRECATED",
+                    "Use VDBSmooth Instead"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "1"
+                ],
+                [
+                    "int",
+                    "width",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "inoutSDF",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "VDBTopoCopy": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "topo",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBTouchAABBRegion": {
+            "inputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "bmax",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VDBVoxelAsParticles": {
+            "inputs": [
+                [
+                    "",
+                    "vdbGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "valToAttr",
+                    "sdf"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "asStaggers",
+                    "1"
+                ],
+                [
+                    "bool",
+                    "hasInactive",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "primPars",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VDBWrangle": {
+            "inputs": [
+                [
+                    "VDBGrid",
+                    "grid",
+                    ""
+                ],
+                [
+                    "string",
+                    "zfxCode",
+                    ""
+                ],
+                [
+                    "enum true false",
+                    "ModifyActive",
+                    "false"
+                ],
+                [
+                    "enum true false",
+                    "ChangeBackground",
+                    "false"
+                ],
+                [
+                    "DictObject:NumericObject",
+                    "params",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "VDBGrid",
+                    "grid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "zenofx"
+            ]
+        },
+        "VectorFieldAnalyzer": {
+            "inputs": [
+                [
+                    "",
+                    "InVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "enum Divergence Curl Magnitude Normalize",
+                    "Operator",
+                    "Divergence"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "OutVDB",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VisPrimAttrValue": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "precision",
+                    "3"
+                ],
+                [
+                    "bool",
+                    "includeSelf",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "dotDecoration",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VisPrimAttrValue_Modify": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "int",
+                    "precision",
+                    "3"
+                ],
+                [
+                    "bool",
+                    "includeSelf",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "dotDecoration",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "VisVec3Attribute": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "string",
+                    "name",
+                    "vel"
+                ],
+                [
+                    "bool",
+                    "normalize",
+                    "1"
+                ],
+                [
+                    "float",
+                    "lengthScale",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "color",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "primVis",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "visualize"
+            ]
+        },
+        "VisualUVObj": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "math"
+            ]
+        },
+        "VolumeAdvect": {
+            "inputs": [
+                [
+                    "",
+                    "InField",
+                    ""
+                ],
+                [
+                    "",
+                    "VecField",
+                    ""
+                ],
+                [
+                    "float",
+                    "TimeStep",
+                    ""
+                ],
+                [
+                    "int",
+                    "SubSteps",
+                    "1"
+                ],
+                [
+                    "enum SemiLagrangian  MidPoint RK3 RK4 MacCormack BFECC",
+                    "Integrator",
+                    "BFECC"
+                ],
+                [
+                    "enum None Clamp Revert",
+                    "Limiter",
+                    "Revert"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "extend",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "VoronoiFracture": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "meshPrim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "particlesPrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "doMeshFix",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "doMeshFix2",
+                    "1"
+                ],
+                [
+                    "int",
+                    "numRandPoints",
+                    "256"
+                ],
+                [
+                    "bool",
+                    "periodicX",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicY",
+                    "0"
+                ],
+                [
+                    "bool",
+                    "periodicZ",
+                    "0"
+                ]
+            ],
+            "outputs": [
+                [
+                    "ListObject",
+                    "primList",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "neighList",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "cgmesh"
+            ]
+        },
+        "WBPrimBend": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "int",
+                    "Limit Deformation",
+                    "1"
+                ],
+                [
+                    "int",
+                    "Symmetric Deformation",
+                    "0"
+                ],
+                [
+                    "float",
+                    "Bend Angle (degree)",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Up Vector",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Capture Origin",
+                    ""
+                ],
+                [
+                    "vec3f",
+                    "Capture Direction",
+                    ""
+                ],
+                [
+                    "float",
+                    "Capture Length",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WXL_PrimProject": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "nrmAttr",
+                    "nrm"
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "limit",
+                    ""
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "PrimitiveObject",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteCustomVAT": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "frameid",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "int",
+                    "frameEnd",
+                    "100"
+                ],
+                [
+                    "int",
+                    "frameStart",
+                    "0"
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteObjMesh": {
+            "inputs": [
+                [
+                    "",
+                    "mesh",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WriteObjPrim": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "bool",
+                    "polygonate",
+                    "1"
+                ]
+            ],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteObjPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WriteParticles": {
+            "inputs": [
+                [
+                    "",
+                    "pars",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "WritePlyPrimitive": {
+            "inputs": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WritePrimToCSV": {
+            "inputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "enum verts points lines tris quads loops polys",
+                    "type",
+                    "verts"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "primitive",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "primitive"
+            ]
+        },
+        "WriteVDB": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "openvdb"
+            ]
+        },
+        "WriteVDBGrid": {
+            "inputs": [
+                [
+                    "",
+                    "data",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "writepath",
+                    "path",
+                    ""
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "ZipListAsDict": {
+            "inputs": [
+                [
+                    "ListObject",
+                    "keys",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "values",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "DictObject",
+                    "dict",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "dict"
+            ]
+        },
+        "erode_compute_erosion": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "debrisLayerName",
+                    "debris"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "10"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "cut_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxdepth",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_domainWarping_v1": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmH",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmFrequence",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmAmplitude",
+                    ""
+                ],
+                [
+                    "int",
+                    "fbmNumOctaves",
+                    "4"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_domainWarping_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmH",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmFrequence",
+                    ""
+                ],
+                [
+                    "float",
+                    "fbmAmplitude",
+                    ""
+                ],
+                [
+                    "int",
+                    "fbmNumOctaves",
+                    "4"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v1": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_hybridMultifractal_v3": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "H",
+                    ""
+                ],
+                [
+                    "float",
+                    "lacunarity",
+                    ""
+                ],
+                [
+                    "float",
+                    "octaves",
+                    ""
+                ],
+                [
+                    "float",
+                    "offset",
+                    ""
+                ],
+                [
+                    "float",
+                    "scale",
+                    ""
+                ],
+                [
+                    "float",
+                    "persistence",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "hybrid"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_analytic_simplex_2d": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "analyticNoise"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_perlin": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "vec3fAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_simplex": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_sparse_convolution": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "int",
+                    "pulsenum",
+                    "3"
+                ],
+                [
+                    "int",
+                    "griddist",
+                    "2"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_noise_worley": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "seed",
+                    ""
+                ],
+                [
+                    "string",
+                    "posLikeAttrName",
+                    "pos"
+                ],
+                [
+                    "float",
+                    "celljitter",
+                    ""
+                ],
+                [
+                    "enum Euclidean Chebyshev Manhattan",
+                    "distType",
+                    "Euclidean"
+                ],
+                [
+                    "enum F1 F2-F1",
+                    "fType",
+                    "F1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "noise"
+                ],
+                [
+                    "enum float float3",
+                    "attrType",
+                    "float"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_precipitation": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "waterLayerName",
+                    "water"
+                ],
+                [
+                    "float",
+                    "amount",
+                    ""
+                ],
+                [
+                    "float",
+                    "density",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "1"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_project": {
+            "inputs": [
+                [
+                    "PrimitiveObject",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "PrimitiveObject",
+                    "targetPrim",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "int",
+                    "hitFarthest",
+                    "1"
+                ],
+                [
+                    "float",
+                    "maxDist",
+                    ""
+                ],
+                [
+                    "int",
+                    "doJitter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "numSamples",
+                    "3"
+                ],
+                [
+                    "float",
+                    "jitterScale",
+                    ""
+                ],
+                [
+                    "int",
+                    "jitterCombine",
+                    "1"
+                ],
+                [
+                    "int",
+                    "seed",
+                    "1"
+                ],
+                [
+                    "int",
+                    "combineMethod",
+                    "3"
+                ],
+                [
+                    "enum front back both",
+                    "allowDir",
+                    "both"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_rand_color": {
+            "inputs": [
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_rand_dir": {
+            "inputs": [
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_slump_b2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "materialLayerName",
+                    "debris"
+                ],
+                [
+                    "string",
+                    "stabilitymaskLayerName",
+                    "_stability"
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "10"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "repose_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "float",
+                    "flow_rate",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_slump_b4": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "heightLayerName",
+                    "height"
+                ],
+                [
+                    "string",
+                    "materialLayerName",
+                    "water"
+                ],
+                [
+                    "string",
+                    "sedimentLayerName",
+                    "sediment"
+                ],
+                [
+                    "string",
+                    "debrisLayerName",
+                    "debris"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_debris_depth",
+                    ""
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "max_erodability_iteration",
+                    "5"
+                ],
+                [
+                    "float",
+                    "initial_erodability_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "slope_contribution_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "bed_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "depositionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "sedimentcap",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_bank_bed_ratio",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "40"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "deprecated"
+            ]
+        },
+        "erode_terrainHiMeLo": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "string",
+                    "attrName",
+                    "fbm"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v0": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "cut_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "maxdepth",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v2": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "0"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "repose_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "float",
+                    "flow_rate",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_tumble_material_v4": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "perm",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "p_dirs",
+                    ""
+                ],
+                [
+                    "ListObject",
+                    "x_dirs",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "int",
+                    "iterations",
+                    "40"
+                ],
+                [
+                    "int",
+                    "iter",
+                    "0"
+                ],
+                [
+                    "int",
+                    "i",
+                    "0"
+                ],
+                [
+                    "int",
+                    "openborder",
+                    "0"
+                ],
+                [
+                    "float",
+                    "gridbias",
+                    ""
+                ],
+                [
+                    "int",
+                    "visualEnable",
+                    "0"
+                ],
+                [
+                    "float",
+                    "global_erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "erodability",
+                    ""
+                ],
+                [
+                    "float",
+                    "erosionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_angle",
+                    ""
+                ],
+                [
+                    "float",
+                    "removalrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_debris_depth",
+                    ""
+                ],
+                [
+                    "int",
+                    "max_erodability_iteration",
+                    "5"
+                ],
+                [
+                    "float",
+                    "initial_erodability_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "slope_contribution_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "bed_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "depositionrate",
+                    ""
+                ],
+                [
+                    "float",
+                    "sedimentcap",
+                    ""
+                ],
+                [
+                    "float",
+                    "bank_erosionrate_factor",
+                    ""
+                ],
+                [
+                    "float",
+                    "max_bank_bed_ratio",
+                    ""
+                ],
+                [
+                    "float",
+                    "quant_amt",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_value2cond": {
+            "inputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "float",
+                    "value",
+                    ""
+                ],
+                [
+                    "float",
+                    "seed",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim_2DGrid",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "erode_voronoi": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "featurePrim",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [
+                [
+                    "string",
+                    "attrName",
+                    "voronoi"
+                ]
+            ],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "erode"
+            ]
+        },
+        "makeCompressibleSim": {
+            "inputs": [
+                [
+                    "",
+                    "inFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "outFlowData",
+                    ""
+                ],
+                [
+                    "",
+                    "SimParam",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "CompressibleFlow"
+            ]
+        },
+        "scnoise": {
+            "inputs": {
+                "SRC": {
+                    "default-value": null,
+                    "control": {
+                        "name": ""
+                    },
+                    "type": ""
+                },
+                "prim": {
+                    "default-value": null,
+                    "control": {
+                        "name": ""
+                    },
+                    "type": ""
+                },
+                "ElementSize": {
+                    "default-value": 0,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "scale": {
+                    "default-value": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "control": {
+                        "name": "Float Vector 3"
+                    },
+                    "type": "vec3f"
+                },
+                "offset": {
+                    "default-value": null,
+                    "control": {
+                        "name": "Float"
+                    },
+                    "type": "float"
+                },
+                "Pulsenum": {
+                    "default-value": 0,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "Griddist": {
+                    "default-value": 0,
+                    "control": {
+                        "name": "Integer"
+                    },
+                    "type": "int"
+                },
+                "Visualize": {
+                    "default-value": false,
+                    "control": {
+                        "name": "Boolean"
+                    },
+                    "type": "bool"
+                }
+            },
+            "params": {},
+            "outputs": {
+                "DST": {},
+                "prim": {}
+            },
+            "categories": [
+                "subgraph"
+            ],
+            "is_subgraph": true
+        },
+        "str2num": {
+            "inputs": [
+                [
+                    "enum float int",
+                    "type",
+                    "int"
+                ],
+                [
+                    "string",
+                    "str",
+                    "0"
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "num",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "testPoly1": {
+            "inputs": [
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        },
+        "testPoly2": {
+            "inputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "list",
+                    ""
+                ],
+                [
+                    "",
+                    "SRC",
+                    ""
+                ]
+            ],
+            "params": [],
+            "outputs": [
+                [
+                    "",
+                    "prim",
+                    ""
+                ],
+                [
+                    "",
+                    "DST",
+                    ""
+                ]
+            ],
+            "categories": [
+                "WBTest"
+            ]
+        }
+    },
+    "version": "v2.5"
+}

--- a/zeno/src/nodes/num/NumericMath.cpp
+++ b/zeno/src/nodes/num/NumericMath.cpp
@@ -226,5 +226,43 @@ ZENDEFNODE(CalcDirectionFromAngle, {
     {"math"},
 });
 
+
+struct DegreetoRad : INode {
+    virtual void apply() override {
+
+        auto degree = get_input2<float>("degree");
+        float radian = degree * 0.01745329251994329576923690768489;
+        set_output2("radian", radian);
+
+    }
+};
+
+ZENDEFNODE(DegreetoRad, {
+    {{"float", "degree", ""}, 
+    },
+    {{"float", "radian"}},
+    {},
+    {"math"},
+});
+
+
+struct RadtoDegree : INode {
+    virtual void apply() override {
+
+        auto radian = get_input2<float>("radian");
+        float degree = radian * 180.f / M_PI;
+        set_output2("degree", degree);
+
+    }
+};
+
+ZENDEFNODE(RadtoDegree, {
+    {{"float", "radian", ""}, 
+    },
+    {{"float", "degree"}},
+    {},
+    {"math"},
+});
+
 }
 }

--- a/zeno/src/nodes/prim/WBNoise.cpp
+++ b/zeno/src/nodes/prim/WBNoise.cpp
@@ -8,6 +8,7 @@
 #include <glm/gtx/quaternion.hpp>
 #include <cmath>
 #include <random>
+//#include <array>
 
 namespace zeno
 {
@@ -774,19 +775,17 @@ ZENDEFNODE(erode_noise_analytic_simplex_2d,
             "erode",
         } });
 
-
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Sparse Convolution Noise
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#define TABSIZE 256 
-#define TABMASK (TABSIZE - 1)
-#define PERM(x) perm[(x)&TABMASK]
-#define INDEX(ix, iy, iz) PERM((ix) + PERM((iy) + PERM(iz))) 
-#define RANDMASK 0x7fffffff
-#define RANDNBR ((rand() & RANDMASK) / (double)RANDMASK)
-#define FLOOR(x) ((int)(x) - ((x) < 0 && (x) != (int)(x)))
+template <typename T>
+constexpr T PERM(T x) {
+    return perm[(x)&255];
+}
 
-unsigned char perm[TABSIZE] = {
+#define INDEX(ix, iy, iz) PERM((ix) + PERM((iy) + PERM(iz)))
+
+std::array<int, 256> perm = {
     225, 155, 210, 108, 175, 199, 221, 144, 203, 116, 70,  213, 69,  158, 33,  252, 5,   82,  173, 133, 222, 139,
     174, 27,  9,   71,  90,  246, 75,  130, 91,  191, 169, 138, 2,   151, 194, 235, 81,  7,   25,  113, 228, 159,
     205, 253, 134, 142, 248, 65,  224, 217, 22,  121, 229, 63,  89,  103, 96,  104, 156, 17,  201, 129, 36,  8,
@@ -798,34 +797,34 @@ unsigned char perm[TABSIZE] = {
     12,  1,   243, 148, 102, 166, 38,  238, 251, 37,  240, 126, 64,  74,  161, 40,  184, 149, 171, 178, 101, 66,
     29,  59,  146, 61,  254, 107, 42,  86,  154, 4,   236, 232, 120, 21,  233, 209, 45,  98,  193, 114, 78,  19,
     206, 14,  118, 127, 48,  79,  147, 85,  30,  207, 219, 54,  88,  234, 190, 122, 95,  67,  143, 109, 137, 214,
-    145, 93,  92,  100, 245, 0,   216, 186, 60,  83,  105, 97,  204, 52
-};
+    145, 93,  92,  100, 245, 0,   216, 186, 60,  83,  105, 97,  204, 52};
 
-float impulseTab[TABSIZE * 4];
-void impulseTabInit(int seed) {
+std::random_device rd;
+std::default_random_engine engine(rd());
+std::uniform_real_distribution<float> d(0, 1);
+
+float impulseTab[256 * 4];
+void impulseTabInit() {
     int i;
     float *f = impulseTab;
-    srand(seed); /* Set random number generator seed. */
-    for (i = 0; i < TABSIZE; i++) {
-        *f++ = RANDNBR;
-        *f++ = RANDNBR;
-        *f++ = RANDNBR;
-        *f++ = 1. - 2. * RANDNBR;
+    for (i = 0; i < 256; i++) {
+        *f++ = d(engine);
+        *f++ = d(engine);
+        *f++ = d(engine);
+        *f++ = 1. - 2. * d(engine);
     }
 }
 
-float catrom2(float d) {
-#define SAMPRATE 100 /* table entries per unit distance */
-#define NENTRIES (4 * SAMPRATE + 1)
+float catrom2(float d, int griddist) {
     float x;
     int i;
-    static float table[NENTRIES];
-    static int initialized = 0;
-    if (d >= 4)
+    static float table[401];
+    static bool initialized = 0;
+    if (d >= griddist * griddist)
         return 0;
     if (!initialized) {
-        for (i = 0; i < NENTRIES; i++) {
-            x = i / (float)SAMPRATE;
+        for (i = 0; i < 4 * 100 + 1; i++) {
+            x = i / (float)100;
             x = sqrtf(x);
             if (x < 1)
                 table[i] = 0.5 * (2 + x * x * (-5 + x * 3));
@@ -834,61 +833,65 @@ float catrom2(float d) {
         }
         initialized = 1;
     }
-    d = d * SAMPRATE + 0.5;
-    i = FLOOR(d);
-    if (i >= NENTRIES)
+    d = d * 100 + 0.5;
+    i = floor(d);
+    if (i >= 4 * 100 + 1)
         return 0;
     return table[i];
 }
 
-#define NEXT(h) (((h) + 1) & TABMASK)
-#define NIMPULSES 3
-float scnoise(float x, float y, float z, int seed) {
+#define NEXT(h) (((h) + 1) & 255)
+
+float scnoise(float x, float y, float z, int pulsenum, int griddist) {
     static int initialized;
-    float *fp;
+    float *fp = nullptr;
     int i, j, k, h, n;
     int ix, iy, iz;
     float sum = 0;
     float fx, fy, fz, dx, dy, dz, distsq;
-    
+
     /* Initialize the random impulse table if necessary. */
     if (!initialized) {
-        //impulseTabInit(665);
-        impulseTabInit(seed);
+        impulseTabInit();
         initialized = 1;
     }
-    ix = FLOOR(x);
+    ix = floor(x);
     fx = x - ix;
-    iy = FLOOR(y);
+    iy = floor(y);
     fy = y - iy;
-    iz = FLOOR(z);
+    iz = floor(z);
     fz = z - iz;
-    
+
     /* Perform the sparse convolution. */
-    for (i = -2; i <= 2; i++) {
-        for (j = -2; j <= 2; j++) {
-            for (k = -2; k <= 2; k++) { /* Compute voxel hash code. */
-                h = INDEX(ix + i, iy + j, iz + k);
-                for (n = NIMPULSES; n > 0; n--, h = NEXT(h)) { /* Convolve filter and impulse. */
-                    fp = &impulseTab[h * 4];
-                    dx = fx - (i + *fp++);
+    for (i = -griddist; i <= griddist; i++) { //周围的grid ： 2*griddist+1
+        for (j = -griddist; j <= griddist; j++) {
+            for (k = -griddist; k <= griddist; k++) {         /* Compute voxel hash code. */
+                h = INDEX(ix + i, iy + j, iz + k);            //PSN
+                for (n = pulsenum; n > 0; n--, h = NEXT(h)) { /* Convolve filter and impulse. */
+                                                              //每个cell内随机产生pulsenum个impulse
+                    fp = &impulseTab[h * 4];                  // get impulse
+                    dx = fx - (i + *fp++);                    //i + *fp++   周围几个晶胞的脉冲
                     dy = fy - (j + *fp++);
                     dz = fz - (k + *fp++);
                     distsq = dx * dx + dy * dy + dz * dz;
-                    sum += catrom2(distsq) * *fp;
+                    sum += catrom2(distsq, griddist) *
+                           *fp; // 第四个fp 指向的就是每个点的权重    filter kernel在gabor noise里面变成了gabor kernel。
                 }
             }
         }
     }
-    return sum / NIMPULSES;
+    return sum / pulsenum;
 }
 
 struct erode_noise_sparse_convolution : INode {
     void apply() override {
+
         auto terrain = get_input<PrimitiveObject>("prim_2DGrid");
-        auto seed = get_input<NumericObject>("seed")->get<int>();
-        auto attrName = get_param<std::string>("attrName");
-        auto attrType = get_param<std::string>("attrType");
+        auto griddist = get_input2<int>("griddist");
+        auto pulsenum = get_input2<int>("pulsenum");
+        auto attrName = get_input2<std::string>("attrName:");
+        auto attrType = get_input2<std::string>("attrType:");
+
         if (!terrain->has_attr(attrName)) {
             if (attrType == "float3")
                 terrain->add_attr<vec3f>(attrName);
@@ -900,18 +903,19 @@ struct erode_noise_sparse_convolution : INode {
         if (!terrain->verts.has_attr(posLikeAttrName)) {
             zeno::log_error("no such data named '{}'.", posLikeAttrName);
         }
+
         auto &pos = terrain->verts.attr<vec3f>(posLikeAttrName);
 
         terrain->attr_visit(attrName, [&](auto &arr) {
-//#pragma omp parallel for
+#pragma omp parallel for
             for (int i = 0; i < arr.size(); i++) {
                 if constexpr (is_decay_same_v<decltype(arr[i]), vec3f>) {
-                    float x = scnoise(pos[i][0], pos[i][1], pos[i][2], seed);
-                    float y = scnoise(pos[i][1], pos[i][2], pos[i][0], seed);
-                    float z = scnoise(pos[i][2], pos[i][0], pos[i][1], seed);
+                    float x = scnoise(pos[i][0], pos[i][1], pos[i][2], pulsenum, griddist);
+                    float y = scnoise(pos[i][1], pos[i][2], pos[i][0], pulsenum, griddist);
+                    float z = scnoise(pos[i][2], pos[i][0], pos[i][1], pulsenum, griddist);
                     arr[i] = vec3f(x, y, z);
                 } else {
-                    arr[i] = scnoise(pos[i][0], pos[i][1], pos[i][2], seed);
+                    arr[i] = scnoise(pos[i][0], pos[i][1], pos[i][2], pulsenum, griddist);
                 }
             }
         });
@@ -919,26 +923,208 @@ struct erode_noise_sparse_convolution : INode {
         set_output("prim_2DGrid", get_input("prim_2DGrid"));
     }
 };
-ZENDEFNODE(erode_noise_sparse_convolution,
-    {/* inputs: */ {
-        "prim_2DGrid",
-        {"string", "posLikeAttrName", "pos"},
-        {"int", "seed", "665"},
-    },
-    /* outputs: */
-    {
-        "prim_2DGrid",
-    },
-    /* params: */
-    {
-        {"string", "attrName", "noise"},
-        {"enum float float3", "attrType", "float"},
-    },
-    /* category: */
-    {
-        "erode",
-    }});
+ZENDEFNODE(erode_noise_sparse_convolution, {/* inputs: */ {
+                                                "prim_2DGrid",
+                                                {"string", "posLikeAttrName", "pos"},
+                                                {"int", "pulsenum", "3"},
+                                                {"int", "griddist", "2"},
+                                            },
+                                            /* outputs: */
+                                            {
+                                                "prim_2DGrid",
+                                            },
+                                            /* params: */
+                                            {
+                                                {"string", "attrName", "noise"},
+                                                {"enum float float3", "attrType", "float"},
+                                            },
+                                            /* category: */
+                                            {
+                                                "erode",
+                                            }});
 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Gabor Noise
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//reference :https://github.com/jijup/OpenSN
+class pseudo_random_number_generator {
+  public:
+    void seed(unsigned s) {
+        x_ = s;
+    }
+    unsigned operator()() {
+        x_ *= 3039177861u;
+        return x_;
+    }
+    float uniform_0_1() {
+        return float(operator()()) / float(0xffffffff);
+    } //unsigner int max
+    float uniform(float min, float max) {
+        return min + (uniform_0_1() * (max - min));
+    }
+    unsigned poisson(float mean) {
+        float g_ = std::exp(-mean);
+        unsigned em = 0;
+        double t = uniform_0_1();
+        while (t > g_) {
+            ++em;
+            t *= uniform_0_1();
+        }
+        return em;
+    }
+
+  private:
+    unsigned x_;
+};
+
+
+float gabor(float K, float a, float F_0, float omega_0, float x, float y) {
+    float gaussian_envelop = K * std::exp(-M_PI * (a * a) * ((x * x) + (y * y)));
+    float sinusoidal_carrier = std::cos(2.0 * M_PI * F_0 * ((x * std::cos(omega_0)) + (y * std::sin(omega_0))));
+    return gaussian_envelop * sinusoidal_carrier;
+}
+
+unsigned morton(unsigned x, unsigned y) {
+    unsigned z = 0;
+    for (unsigned i = 0; i < (sizeof(unsigned) * 8); ++i) { //char bit-----8
+        z |= ((x & (1 << i)) << i) | ((y & (1 << i)) << (i + 1));
+    }
+    return z;
+}
+
+class Gnoise {
+  public:
+    Gnoise(float K, float a, float F_0, float omega_0, float number_of_impulses_per_kernel, 
+          unsigned random_offset, bool isotropic)
+        : K_(K), a_(a), F_0_(F_0), omega_0_(omega_0), random_offset_(random_offset), isotropic_(isotropic)
+    {
+        kernel_radius_ = std::sqrt(-std::log(0.05) / M_PI) / a_;
+        impulse_density_ = number_of_impulses_per_kernel / (M_PI * kernel_radius_ * kernel_radius_);
+    }
+
+    float operator()(float x, float y) const {
+        x /= kernel_radius_, y /= kernel_radius_;
+        float int_x = std::floor(x), int_y = std::floor(y);
+        float frac_x = x - int_x, frac_y = y - int_y;
+        int i = int(int_x), j = int(int_y);
+        float noise = 0.0;
+        for (int di = -1; di <= +1; ++di) {
+            for (int dj = -1; dj <= +1; ++dj) {
+                noise += cell(i + di, j + dj, frac_x - di, frac_y - dj);
+            }
+        }
+        return noise;
+    }
+
+    float cell(int i, int j, float x, float y) const {
+ 
+        unsigned s = morton(i, j) + random_offset_ + 1; // nonperiodic noise
+        
+        pseudo_random_number_generator prng;
+        prng.seed(s);
+
+        double number_of_impulses_per_cell = impulse_density_ * kernel_radius_ * kernel_radius_;
+        unsigned number_of_impulses = prng.poisson(number_of_impulses_per_cell);
+        float noise = 0.0;
+
+        for (unsigned i = 0; i < number_of_impulses; ++i) {
+            float x_i = prng.uniform_0_1();
+            float y_i = prng.uniform_0_1();
+            float w_i = prng.uniform(-1.0, +1.0);
+            float omega_0_i = prng.uniform(0.0, 2.0 * M_PI);
+            float x_i_x = x - x_i;
+            float y_i_y = y - y_i;
+            if (((x_i_x * x_i_x) + (y_i_y * y_i_y)) < 1.0) {
+                if(isotropic_)
+                    noise += w_i * gabor(K_, a_, F_0_, omega_0_i, x_i_x * kernel_radius_, y_i_y * kernel_radius_);
+                else
+                    noise += w_i * gabor(K_, a_, F_0_, omega_0_, x_i_x * kernel_radius_, y_i_y * kernel_radius_); 
+            }
+        }
+        return noise;
+    }
+
+    float variance() const {
+        float integral_gabor_filter_squared =
+            ((K_ * K_) / (4.0 * a_ * a_)) * (1.0 + std::exp(-(2.0 * M_PI * F_0_ * F_0_) / (a_ * a_)));
+        return impulse_density_ * (1.0 / 3.0) * integral_gabor_filter_squared;
+    }
+
+  private:
+    float K_;
+    float a_;
+    float F_0_;
+    float omega_0_;
+    float kernel_radius_;
+    float impulse_density_;
+    unsigned random_offset_;
+    bool isotropic_;
+};
+
+
+struct Noise_gabor_2d : INode {
+    void apply() override {
+
+        auto terrain = get_input<PrimitiveObject>("prim_2DGrid");
+        auto attrName = get_input2<std::string>("attrName:");
+
+        auto a_ = get_input2<float>("a_");
+        auto F_0_ = get_input2<float>("frequency");
+        auto omega_0_ = get_input2<float>("Orientation");
+        auto number_of_impulses_per_kernel = get_input2<int>("impulses_per_kernel");
+        auto isotropic = get_input2<bool>("isotropic");
+        auto random_offset = get_input2<float>("offset");
+
+        if (!terrain->has_attr(attrName)) {
+            terrain->add_attr<float>(attrName);
+        }
+        auto &noise = terrain->verts.attr<float>(attrName);
+
+        auto posLikeAttrName = get_input<StringObject>("posLikeAttrName")->get();
+        if (!terrain->verts.has_attr(posLikeAttrName)) {
+            zeno::log_error("no such data named '{}'.", posLikeAttrName);
+        }
+        auto &pos = terrain->verts.attr<vec3f>(posLikeAttrName);
+        
+        glm::vec3 ret{};
+        auto K_ = 2.5f;  // act on spectrum
+
+        Gnoise noise_(K_, a_, F_0_, omega_0_, number_of_impulses_per_kernel, random_offset, isotropic);
+        float scale = 3.0 * std::sqrt(noise_.variance());
+
+#pragma omp parallel for
+        for (int i = 0; i < terrain->verts.size(); i++) {
+            float noise2dV = 0.5 + 0.5 * noise_(pos[i][0], pos[i][2]) / scale;
+
+            noise[i] = noise2dV; //直接float？
+        }
+
+        set_output("prim_2DGrid", get_input("prim_2DGrid"));
+    }
+};
+
+ZENDEFNODE(Noise_gabor_2d, {/* inputs: */ {
+                                      "prim_2DGrid",
+                                      {"string", "posLikeAttrName", "pos"},
+                                      {"float", "a_", "0.07"},
+                                      {"float", "frequency", "0.2"},
+                                      {"float", "Orientation", "0.8"},
+                                      {"int", "impulses_per_kernel", "64"},
+                                      {"bool", "isotropic", "0"},
+                                      {"float", "offset", "15"},
+                                  },
+                                  /* outputs: */
+                                  {
+                                      "prim_2DGrid",
+                                  },
+                                  /* params: */
+                                  {
+                                      {"string", "attrName", "noise"},
+                                  },
+                                  /* category: */
+                                  {
+                                      "erode",
+                                  }});
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Worley Noise
@@ -969,7 +1155,7 @@ float noise_mydistance(glm::vec3 a, glm::vec3 b, int t) {
     }
 }
 
-float noise_WorleyNoise3(float px, float py, float pz, int fType, int distType, float offsetX, float offsetY, float offsetZ) {
+float noise_WorleyNoise3(float px, float py, float pz, int fType, int distType, float offsetX, float offsetY, float offsetZ, float jitter = 1) {
     glm::vec3 pos = glm::vec3(px, py, pz);
     glm::vec3 offset = glm::vec3(offsetX, offsetY, offsetZ);
     glm::vec3 i_pos = floor(pos);
@@ -984,7 +1170,9 @@ float noise_WorleyNoise3(float px, float py, float pz, int fType, int distType, 
                 glm::vec3 neighbor = glm::vec3(float(x), float(y), float(z));
                 glm::vec3 point = noise_random3(i_pos + neighbor);
                 point = (float)0.5 + (float)0.5 * sin(offset + (float)6.2831 * point);
-                glm::vec3 featurePoint = neighbor + point;
+                point = point * jitter;
+                glm::vec3 featurePoint = neighbor + point; 
+
                 float dist = noise_mydistance(featurePoint, f_pos, distType);
                 if (dist < f1) {
                     f2 = f1; f1 = dist;
@@ -1007,7 +1195,13 @@ float noise_WorleyNoise3(float px, float py, float pz, int fType, int distType, 
 struct erode_noise_worley : INode {
     void apply() override {
         auto terrain = get_input<PrimitiveObject>("prim_2DGrid");
-
+        auto posLikeAttrName = get_input<StringObject>("posLikeAttrName")->get();
+        if (!terrain->verts.has_attr(posLikeAttrName))
+        {
+            zeno::log_error("no such data named '{}'.", posLikeAttrName);
+        }
+        auto& pos = terrain->verts.attr<vec3f>(posLikeAttrName);
+        auto jitter = get_input2<float>("celljitter");
         vec3f offset;
         if (!has_input("seed")) {
             std::mt19937 gen(std::random_device{}());
@@ -1031,7 +1225,6 @@ struct erode_noise_worley : INode {
 
         auto attrName = get_param<std::string>("attrName");
         auto attrType = get_param<std::string>("attrType");
-        auto& pos = terrain->verts;
 
         if (!terrain->has_attr(attrName)) {
             if (attrType == "float3") terrain->add_attr<vec3f>(attrName);
@@ -1044,14 +1237,14 @@ struct erode_noise_worley : INode {
             {
                 if constexpr (is_decay_same_v<decltype(arr[i]), vec3f>)
                 {
-                    float x = noise_WorleyNoise3(pos[i][0], pos[i][1], pos[i][2], fType, distType, offset[0], offset[1], offset[2]);
-                    float y = noise_WorleyNoise3(pos[i][1], pos[i][2], pos[i][0], fType, distType, offset[0], offset[1], offset[2]);
-                    float z = noise_WorleyNoise3(pos[i][2], pos[i][0], pos[i][1], fType, distType, offset[0], offset[1], offset[2]);
+                    float x = noise_WorleyNoise3(pos[i][0], pos[i][1], pos[i][2], fType, distType, offset[0], offset[1], offset[2], jitter);
+                    float y = noise_WorleyNoise3(pos[i][1], pos[i][2], pos[i][0], fType, distType, offset[0], offset[1], offset[2], jitter);
+                    float z = noise_WorleyNoise3(pos[i][2], pos[i][0], pos[i][1], fType, distType, offset[0], offset[1], offset[2], jitter);
                     arr[i] = vec3f(x, y, z);
                 }
                 else
                 {
-                    arr[i] = noise_WorleyNoise3(pos[i][0], pos[i][1], pos[i][2], fType, distType, offset[0], offset[1], offset[2]);
+                    arr[i] = noise_WorleyNoise3(pos[i][0], pos[i][1], pos[i][2], fType, distType, offset[0], offset[1], offset[2], jitter);
                 }
             }
             });
@@ -1063,6 +1256,8 @@ ZENDEFNODE(erode_noise_worley,
     { /* inputs: */ {
         "prim_2DGrid",
         "seed",
+        {"string", "posLikeAttrName", "pos"},
+        {"float", "celljitter", "1"},
         {"enum Euclidean Chebyshev Manhattan", "distType", "Euclidean"},
         {"enum F1 F2-F1", "fType", "F1"},
     }, /* outputs: */ {


### PR DESCRIPTION
### 1.
大概使用文档：：[scnoise](http://doc.zenustech.com/project-5/doc-327/)， [gabor noise](http://doc.zenustech.com/project-5/doc-328/)
![image](https://user-images.githubusercontent.com/83103239/223649420-8c7d72b4-2186-4e89-a543-4b7c21a259e9.png)

)
### 2. 
wik里有一些原理 [Zenowiki](http://192.168.10.2:53000/zh/artist/Asher/Noise)
![image](https://user-images.githubusercontent.com/83103239/223648969-3dbcf462-9d2e-4648-a2b7-5470b5677337.png)
### 3.
两个zsg使用例，里面有子图

![image](https://user-images.githubusercontent.com/83103239/223649797-f9e82d0f-f03c-4b6f-a53f-b36522e3fd6a.png)

子图因为使用了新版的特性， 建议用Zeno2_fixbug分支编译的打开
### 4.
角度和弧度的互相转换，如果在wrangle里面转换的话， 可以手写比较方便，但是如果是节点的情况， 需要先一个Numericwrangle，再dict get item，有点麻烦，所以写了转换节点。