### PR TITLE
[fixed bug] wrong newPos in releaseEvent

### DIFF
--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1327,13 +1327,13 @@ void ZenoNode::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
     {
         m_bMoving = false;
         IGraphsModel* pGraphsModel = zenoApp->graphsManagment()->currentModel();
-        QPointF newPos = event->scenePos();
+        QPointF newPos = this->scenePos();
         QPointF oldPos = m_index.data(ROLE_OBJPOS).toPointF();
         if (newPos != oldPos)
         {
             STATUS_UPDATE_INFO info;
             info.role = ROLE_OBJPOS;
-            info.newValue = m_lastMovig;
+            info.newValue = m_lastMoving;
             info.oldValue = oldPos;
             pGraphsModel->updateNodeStatus(nodeId(), info, m_subGpIndex, false);
 
@@ -1344,7 +1344,7 @@ void ZenoNode::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
             emit outSocketPosChanged();
             //emit nodePosChangedSignal();
 
-            m_lastMovig = QPointF();
+            m_lastMoving = QPointF();
 
             //other selected items also need update model data
             for (QGraphicsItem *item : this->scene()->selectedItems()) {
@@ -1392,7 +1392,7 @@ QVariant ZenoNode::itemChange(GraphicsItemChange change, const QVariant &value)
     else if (change == QGraphicsItem::ItemPositionHasChanged)
     {
         m_bMoving = true;
-        m_lastMovig = value.toPointF();
+        m_lastMoving = value.toPointF();
         emit inSocketPosChanged();
         emit outSocketPosChanged();
     }

--- a/ui/zenoedit/nodesys/zenonode.h
+++ b/ui/zenoedit/nodesys/zenonode.h
@@ -157,7 +157,7 @@ private:
     bool m_bError;
     bool m_bEnableSnap;
     bool m_bMoving;     //pos change flag.
-    QPointF m_lastMovig;    //last moving pos.
+    QPointF m_lastMoving;    //last moving pos.
 
     // when zoom out the view, the view of node will be displayed as text with large size font.
     // it's convenient to view all nodes in big scale picture, but it also brings some problem.


### PR DESCRIPTION
when in snap grid mode, event->scenePos() != this->scenePos(), and if mouse move deta is less than SCENE_GRID_SIZE the node pos will not change
