### PR TITLE
[fix] check pModel is nullptr

### DIFF
--- a/ui/zenoedit/nodesview/zenographseditor.cpp
+++ b/ui/zenoedit/nodesview/zenographseditor.cpp
@@ -408,7 +408,7 @@ void ZenoGraphsEditor::selectTab(const QString& subGraphName, const QString& pat
     auto graphsMgm = zenoApp->graphsManagment();
     IGraphsModel* pModel = graphsMgm->currentModel();
 
-    if (!pModel->index(subGraphName).isValid())
+    if (!pModel || !pModel->index(subGraphName).isValid())
         return;
 
     int idx = tabIndexOfName(subGraphName);


### PR DESCRIPTION
there is no model when the first time open editor, so if move mouse:
```ViewportWidget::mouseReleaseEvent``` -> ```CameraControl::fakeMouseReleaseEvent``` -> ```ZenoGraphsEditor::selectTab```, and crash