### PR TITLE
[fix] cmake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ function (zeno_add_asset_dir dir)
 endfunction()
 ## --- end cihou asset dir
 
+add_subdirectory(zeno)
+
 ## --- begin cihou perf-geeks
 if (ZENO_MARCH_NATIVE)
     if (MSVC)
@@ -182,8 +184,6 @@ if (ZENO_USE_FAST_MATH)
     endif()
 endif()
 ## --- end cihou perf-geeks
-
-add_subdirectory(zeno)
 
 target_compile_options(zeno
             PUBLIC $<$<COMPILE_LANGUAGE:CXX>: $<IF:$<CXX_COMPILER_ID:MSVC>, /utf-8, >>


### PR DESCRIPTION

no target named zeno
```
  ## --- begin cihou perf-geeks
  if (ZENO_MARCH_NATIVE)
      if (MSVC)
          target_compile_options(zeno PRIVATE /arch:AVX)
      else()
          target_compile_options(zeno PRIVATE "-march=native")
      endif()
  endif()
  if (ZENO_USE_FAST_MATH)
      if (MSVC)
          target_compile_options(zeno PRIVATE /fp:fast)
      else()
          target_compile_options(zeno PRIVATE "-ffast-math")
      endif()
  endif()
  ## --- end cihou perf-geeks
 ```
until add subdir
```
  add_subdirectory(zeno)
```

