### PR TITLE
fix: wait cache remove if cachedir is too large

### DIFF
--- a/ui/zenoedit/nodesview/zenographseditor.cpp
+++ b/ui/zenoedit/nodesview/zenographseditor.cpp
@@ -886,7 +886,7 @@ void ZenoGraphsEditor::onAction(QAction* pAction, const QVariantList& args, bool
                 pSpinBox->clear();
                 pathLineEdit->clear();
                 pAutoDelCache->setCheckState(Qt::Unchecked);
-                pRemoveCurFrameCache->setCheckable(Qt::Unchecked);
+                pRemoveCurFrameCache->setCheckState(Qt::Unchecked);
             }
             pSpinBox->setEnabled(state);
             pathLineEdit->setEnabled(state);

--- a/ui/zenoedit/recordmain.cpp
+++ b/ui/zenoedit/recordmain.cpp
@@ -74,6 +74,7 @@ int record_main(const QCoreApplication& app)
         {"video", "video", "export video"},
         {"videoname", "videoname", "export video's name"},
         {"subzsg", "subgraphzsg", "subgraph zsg file path"},
+        {"cacheautorm", "cacheautoremove", "remove cache after render"},
     });
     cmdParser.process(app);
 
@@ -100,14 +101,35 @@ int record_main(const QCoreApplication& app)
         text.replace('\\', '/');
         QSettings settings(zsCompanyName, zsEditor);
         settings.setValue("zencachedir", text);
+        settings.setValue("zencache-enable", true);
+        settings.setValue("zencache-autoremove", false);
         if (!QDir(text).exists()) {
             QDir().mkdir(text);
         }
+        if (cmdParser.isSet("cacheautorm"))
+        {
+            bool autorm = cmdParser.value("cacheautorm").toInt();
+            QSettings settings(zsCompanyName, zsEditor);
+            settings.setValue("zencache-rmcurcache", autorm);
+        }
+        else {
+            QSettings settings(zsCompanyName, zsEditor);
+            settings.setValue("zencache-rmcurcache", false);
+        }
+        if (cmdParser.isSet("cacheNum")) {
+            QString text2 = cmdParser.value("cacheNum");
+            QSettings settings(zsCompanyName, zsEditor);
+            settings.setValue("zencachenum", text2);
+        }
+        else {
+            QSettings settings(zsCompanyName, zsEditor);
+            settings.setValue("zencachenum", 1);
+        }
     }
-    if (cmdParser.isSet("cacheNum")) {
-        QString text2 = cmdParser.value("cacheNum");
+    else {
         QSettings settings(zsCompanyName, zsEditor);
-        settings.setValue("zencachenum", text2);
+        settings.setValue("zencache-enable", true);
+        settings.setValue("zencache-autoremove", true);
     }
     if (cmdParser.isSet("exitWhenRecordFinish"))
         param.exitWhenRecordFinish = cmdParser.value("exitWhenRecordFinish").toLower() == "true";

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -32,7 +32,7 @@ struct GlobalComm {
     ZENO_API void initFrameRange(int beg, int end);
     ZENO_API void newFrame();
     ZENO_API void finishFrame();
-    ZENO_API void dumpFrameCache(int frameid, bool cacheLightCameraOnly = false, bool cacheMaterialOnly = false);
+    ZENO_API void dumpFrameCache(int frameid, size_t& cacheDirSize, bool cacheLightCameraOnly = false, bool cacheMaterialOnly = false);
     ZENO_API void addViewObject(std::string const &key, std::shared_ptr<IObject> object);
     ZENO_API int maxPlayFrames();
     ZENO_API int numOfFinishedFrame();


### PR DESCRIPTION
1. in "remove cache after render" mode, calculate process wait if root cache folder is larger than 200GB
2. record video by command line can set cache root path and enbale "remove cache after render" like:
--cachePath "C:/xxx/cacheroot" --cacheautorm 1
cacheautorm will not take effect if cachePath is missing