### PR TITLE
[fix] picker bug

### DIFF
--- a/ui/zenoedit/viewportinteraction/picker.cpp
+++ b/ui/zenoedit/viewportinteraction/picker.cpp
@@ -151,9 +151,17 @@ void Picker::pick(int x0, int y0, int x1, int y1) {
     auto selected = picker->getPicked(x0, y0, x1, y1);
     // qDebug() << "pick: " << selected.c_str();
     if (scene->select_mode == zenovis::PICK_OBJECT) {
+        if (selected.empty()) {
+            selected_prims.clear();
+            return;
+        }
         load_from_str(selected, zenovis::PICK_OBJECT);
     }
     else {
+        if (selected.empty()) {
+            selected_elements.clear();
+            return;
+        }
         load_from_str(selected, scene->select_mode);
         if (picked_elems_callback) picked_elems_callback(selected_elements);
     }

--- a/zenovis/src/bate/FrameBufferPicker.cpp
+++ b/zenovis/src/bate/FrameBufferPicker.cpp
@@ -481,11 +481,11 @@ struct FrameBufferPicker : IPicker {
 
         string result;
         if (scene->select_mode == zenovis::PICK_OBJECT) {
-            if (!pixel.has_object()) return "";
+            if (!pixel.has_object() || !id_table.count(pixel.obj_id)) return "";
             result = id_table[pixel.obj_id];
         }
         else {
-            if (!pixel.has_object() || !pixel.has_element()) return "";
+            if (!pixel.has_object() || !pixel.has_element() || !id_table.count(pixel.obj_id)) return "";
             result = id_table[pixel.obj_id] + ":" + std::to_string(pixel.elem_id - 1);
         }
 
@@ -517,8 +517,8 @@ struct FrameBufferPicker : IPicker {
 
         // read pixels
         int pixel_count = rect_w * rect_h;
-        auto* pixels = new PixelInfo[pixel_count];
-        CHECK_GL(glReadPixels(start_x, start_y, rect_w, rect_h, GL_RGB_INTEGER, GL_UNSIGNED_INT, pixels));
+        std::vector<PixelInfo> pixels(pixel_count);
+        CHECK_GL(glReadPixels(start_x, start_y, rect_w, rect_h, GL_RGB_INTEGER, GL_UNSIGNED_INT, pixels.data()));
 
         // output buffer to image
 //        auto* img_pixels = new PixelInfo[w * h];


### PR DESCRIPTION
1. forget clear selected prims/elements in ```Picker::pick(int x0, int y0, int x1, int y1)```
2. new with no delete in ```string getPicked(int x0, int y0, int x1, int y1)```
3. ```glReadPixels``` copy data to ```PixelInfo```, and sometimes ```PixelInfo.obj_id``` is a strange number(have not found why...), so check if the obj_id is in id table
    ```
    if (!pixel.has_object() || !id_table.count(pixel.obj_id)) return "";
            result = id_table[pixel.obj_id]; // operator[] will insert if such key does not already exist
    ```