### PR TITLE
[fix] clear changed nodes

### DIFF
--- a/ui/zenomodel/src/graphsmodel.cpp
+++ b/ui/zenomodel/src/graphsmodel.cpp
@@ -1514,7 +1514,7 @@ void GraphsModel::_markNodeChanged(const QModelIndex& nodeIdx)
     QAbstractItemModel* pModel = const_cast<QAbstractItemModel*>(nodeIdx.model());
     ZASSERT_EXIT(pModel);
     pModel->setData(nodeIdx, true, ROLE_NODE_DATACHANGED);
-    m_changedNodes.append(nodeIdx);
+    m_changedNodes.insert(nodeIdx);
 }
 
 void GraphsModel::clearNodeDataChanged()
@@ -1522,8 +1522,8 @@ void GraphsModel::clearNodeDataChanged()
     for (auto nodeIdx : m_changedNodes)
     {
         QAbstractItemModel* pModel = const_cast<QAbstractItemModel*>(nodeIdx.model());
-        ZASSERT_EXIT(pModel);
-        pModel->setData(nodeIdx, false, ROLE_NODE_DATACHANGED);
+        if (pModel)
+            pModel->setData(nodeIdx, false, ROLE_NODE_DATACHANGED);
     }
     m_changedNodes.clear();
 }

--- a/ui/zenomodel/src/graphsmodel.h
+++ b/ui/zenomodel/src/graphsmodel.h
@@ -194,7 +194,7 @@ private:
 
     //LinkModel* m_linkModel;
     QHash<QString, LinkModel*> m_linksGroup;
-    QList<QPersistentModelIndex> m_changedNodes;
+    QSet<QPersistentModelIndex> m_changedNodes;
 
     NODE_DESCS m_nodesDesc;
     NODE_DESCS m_subgsDesc;


### PR DESCRIPTION
* ```m_changedNodes``` is a ```QList```, ```_markNodeChanged```will append same node multi times，this maybe not important...

* ZASSERT_EXIT will **return** , when a node is deleted, pModel will be nullptr, it's a normal, no need to return and ```log_error```
  ```
    for (auto nodeIdx : m_changedNodes)
    {
        QAbstractItemModel* pModel = const_cast<QAbstractItemModel*>(nodeIdx.model());
        ZASSERT_EXIT(pModel); // just continue
        pModel->setData(nodeIdx, false, ROLE_NODE_DATACHANGED);
    }
    m_changedNodes.clear(); // it ZASSERT_EXIT, will be unreachable
```

