### PR TITLE
BvhWrangle Support RadiusAttr

### DIFF
--- a/projects/ZenoFX/LinearBvh.cpp
+++ b/projects/ZenoFX/LinearBvh.cpp
@@ -68,20 +68,37 @@ LBvh::getBvFunc(const std::shared_ptr<PrimitiveObject> &prim) const {
       return bv;
     };
   else if (eleCategory == element_e::point)
-    getBv = [&points = prim->points, &refpos = prim->attr<vec3f>("pos"), 
-    radius = radiusAttr == "" ? std::vector<float>(prim->verts.size(), 0.0f) : prim->verts.attr<float>(radiusAttr),
+      if (radiusAttr == "") {
+        getBv = [&points = prim->points, &refpos = prim->attr<vec3f>("pos"),  
              defaultBox, this](Ti i) -> Box {
-      auto point = points[i];
-      Box bv = defaultBox;
-      const auto &p = refpos[point];
-      for (int d = 0; d != 3; ++d) {
-        if (p[d] - thickness - radius[i] < bv.first[d])
-          bv.first[d] = p[d] - thickness - radius[i];
-        if (p[d] + thickness + radius[i] > bv.second[d])
-          bv.second[d] = p[d] + thickness + radius[i];
-      }
+        auto point = points[i];
+        Box bv = defaultBox;
+        const auto &p = refpos[point];
+        for (int d = 0; d != 3; ++d) {
+          if (p[d] - thickness < bv.first[d])
+            bv.first[d] = p[d] - thickness ;
+          if (p[d] + thickness > bv.second[d])
+            bv.second[d] = p[d] + thickness;
+          }
       return bv;
-    };
+        };
+      } 
+      else {
+        getBv = [&points = prim->points, &refpos = prim->attr<vec3f>("pos"), 
+        &radius = prim->verts.attr<float>(radiusAttr),
+             defaultBox, this](Ti i) -> Box {
+        auto point = points[i];
+        Box bv = defaultBox;
+        const auto &p = refpos[point];
+        for (int d = 0; d != 3; ++d) {
+          if (p[d] - thickness - radius[i] < bv.first[d])
+            bv.first[d] = p[d] - thickness - radius[i];
+          if (p[d] + thickness + radius[i] > bv.second[d])
+            bv.second[d] = p[d] + thickness + radius[i];
+          }
+      return bv;
+      };
+    }
   else if (eleCategory == element_e::unknown)
     getBv = [defaultBox](Ti) -> Box { return defaultBox; };
   return getBv;

--- a/projects/ZenoFX/LinearBvh.cpp
+++ b/projects/ZenoFX/LinearBvh.cpp
@@ -68,16 +68,17 @@ LBvh::getBvFunc(const std::shared_ptr<PrimitiveObject> &prim) const {
       return bv;
     };
   else if (eleCategory == element_e::point)
-    getBv = [&points = prim->points, &refpos = prim->attr<vec3f>("pos"),
+    getBv = [&points = prim->points, &refpos = prim->attr<vec3f>("pos"), 
+    radius = radiusAttr == "" ? std::vector<float>(prim->verts.size(), 0.0f) : prim->verts.attr<float>(radiusAttr),
              defaultBox, this](Ti i) -> Box {
       auto point = points[i];
       Box bv = defaultBox;
       const auto &p = refpos[point];
       for (int d = 0; d != 3; ++d) {
-        if (p[d] - thickness < bv.first[d])
-          bv.first[d] = p[d] - thickness;
-        if (p[d] + thickness > bv.second[d])
-          bv.second[d] = p[d] + thickness;
+        if (p[d] - thickness - radius[i] < bv.first[d])
+          bv.first[d] = p[d] - thickness - radius[i];
+        if (p[d] + thickness + radius[i] > bv.second[d])
+          bv.second[d] = p[d] + thickness + radius[i];
       }
       return bv;
     };
@@ -87,11 +88,11 @@ LBvh::getBvFunc(const std::shared_ptr<PrimitiveObject> &prim) const {
 }
 
 template <LBvh::element_e et>
-void LBvh::build(const std::shared_ptr<PrimitiveObject> &prim, float thickness,
+void LBvh::build(const std::shared_ptr<PrimitiveObject> &prim, float thickness, std::string radiusAttr,
                  element_t<et>) {
   this->primPtr = prim;
   this->thickness = thickness;
-
+  this->radiusAttr = radiusAttr;
   Ti numLeaves = 0; // refpos.size();
 
   {
@@ -451,30 +452,30 @@ void LBvh::build(const std::shared_ptr<PrimitiveObject> &prim, float thickness,
 
 template void
 LBvh::build<LBvh::element_e::point>(const std::shared_ptr<PrimitiveObject> &,
-                                    float, element_t<element_e::point>);
+                                    float, std::string, element_t<element_e::point>);
 template void
 LBvh::build<LBvh::element_e::line>(const std::shared_ptr<PrimitiveObject> &,
-                                   float, element_t<element_e::line>);
+                                   float, std::string, element_t<element_e::line>);
 template void
 LBvh::build<LBvh::element_e::tri>(const std::shared_ptr<PrimitiveObject> &,
-                                  float, element_t<element_e::tri>);
+                                  float, std::string, element_t<element_e::tri>);
 template void
 LBvh::build<LBvh::element_e::tet>(const std::shared_ptr<PrimitiveObject> &,
-                                  float, element_t<element_e::tet>);
+                                  float, std::string, element_t<element_e::tet>);
 
 void LBvh::build(const std::shared_ptr<PrimitiveObject> &prim,
-                 float thickness) {
+                 float thickness, std::string radiusAttr) {
   // determine element category
   if (prim->quads.size() > 0)
-    build(prim, thickness, element_c<element_e::tet>);
+    build(prim, thickness, radiusAttr, element_c<element_e::tet>);
   else if (prim->tris.size() > 0)
-    build(prim, thickness, element_c<element_e::tri>);
+    build(prim, thickness, radiusAttr, element_c<element_e::tri>);
   else if (prim->lines.size() > 0)
-    build(prim, thickness, element_c<element_e::line>);
+    build(prim, thickness, radiusAttr, element_c<element_e::line>);
   else if (prim->points.size() > 0)
-    build(prim, thickness, element_c<element_e::point>);
+    build(prim, thickness, radiusAttr, element_c<element_e::point>);
   else
-    build(prim, thickness, element_c<element_e::point>);
+    build(prim, thickness, radiusAttr, element_c<element_e::point>);
 }
 
 void LBvh::refit() {

--- a/projects/ZenoFX/pnbvhw.cpp
+++ b/projects/ZenoFX/pnbvhw.cpp
@@ -131,7 +131,7 @@ static void bvh_vectors_wrangle_radius(zfx::x64::Executable *exec,
     }
     lbvh->iter_neighbors_radius(pos[i], radius[i], [&](int pid) {
       if (!isBox)
-        if (lengthSquared(pos[i] - opos[pid]) > radius2 + radius[i] * radius[i])//要改 加入radius
+        if (lengthSquared(pos[i] - opos[pid]) > radius2 + radius[i] * radius[i])
           return;
       for (int k = 0; k < chs.size(); k++) {
         if (chs[k].which)

--- a/projects/ZenoFX/pnbvhw.cpp
+++ b/projects/ZenoFX/pnbvhw.cpp
@@ -111,6 +111,41 @@ static void bvh_vectors_wrangle(zfx::x64::Executable *exec,
   }
 }
 
+static void bvh_vectors_wrangle_radius(zfx::x64::Executable *exec,
+                                std::vector<Buffer> const &chs,
+                                std::vector<Buffer> const &chs2,
+                                std::vector<zeno::vec3f> const &pos,
+                                std::vector<float> const &radius,
+                                std::vector<zeno::vec3f> const &opos,
+                                bool isBox, float radius2,
+                                zeno::LBvh *lbvh) {
+  if (chs.size() == 0)
+    return;
+
+#pragma omp parallel for
+  for (int i = 0; i < pos.size(); i++) {
+    auto ctx = exec->make_context();
+    for (int k = 0; k < chs.size(); k++) {
+      if (!chs[k].which)
+        ctx.channel(k)[0] = chs[k].base[chs[k].stride * i];
+    }
+    lbvh->iter_neighbors_radius(pos[i], radius[i], [&](int pid) {
+      if (!isBox)
+        if (lengthSquared(pos[i] - opos[pid]) > radius2 + radius[i] * radius[i])//要改 加入radius
+          return;
+      for (int k = 0; k < chs.size(); k++) {
+        if (chs[k].which)
+          ctx.channel(k)[0] = chs2[k].base[chs2[k].stride * pid];
+      }
+      ctx.execute();
+    });
+    for (int k = 0; k < chs.size(); k++) {
+      if (!chs[k].which)
+        chs[k].base[chs[k].stride * i] = ctx.channel(k)[0];
+    }
+  }
+}
+
 struct ParticlesBuildBvh : zeno::INode {
   virtual void apply() override {
     auto primNei = get_input<zeno::PrimitiveObject>("primNei");
@@ -172,6 +207,26 @@ ZENDEFNODE(BuildPrimitiveBvh,
                {{"enum auto point line tri quad", "prim_type", "auto"}},
                {"zenofx"},
            });
+
+struct ParticlesBuildBvhRadius : zeno::INode {
+  virtual void apply() override {
+    auto prim = get_input<zeno::PrimitiveObject>("prim");
+    float radius = get_input2<float>("basicRadius");
+    auto radiusAttr = get_input2<std::string>("radiusAttr");
+    auto lbvh = std::make_shared<zeno::LBvh>(
+        prim, radius, radiusAttr, zeno::LBvh::element_c<zeno::LBvh::element_e::point>);
+    set_output("lbvh", std::move(lbvh));
+  }
+};
+
+ZENDEFNODE(ParticlesBuildBvhRadius, {
+                                  {{"PrimitiveObject", "prim"},
+                                   {"float", "basicRadius", "1"},
+                                   {"string", "radiusAttr", ""}},
+                                  {{"LBvh", "lbvh"}},
+                                  {},
+                                  {"zenofx"},
+                              });
 
 struct RefitPrimitiveBvh : zeno::INode {
   virtual void apply() override {
@@ -862,5 +917,236 @@ ZENDEFNODE(ParticlesNeighborBvhWrangleSorted,
                {},
                {"zenofx"},
            });
+
+
+struct ParticlesNeighborBvhRadiusWrangle : zeno::INode {
+  virtual void apply() override {
+    auto prim = get_input<zeno::PrimitiveObject>("prim");
+    auto primNei = get_input<zeno::PrimitiveObject>("primNei");
+    auto lbvh = get_input<zeno::LBvh>("lbvh");
+    auto code = get_input<zeno::StringObject>("zfxCode")->get();
+    auto radiusAttr = get_input2<std::string>("radiusAttr");
+
+    if (prim->size() == 0 || primNei->size() == 0) {
+      set_output("prim", std::move(prim));
+      return;
+    }
+
+        // BEGIN张心欣快乐自动加@IND
+        if (auto pos = code.find("@IND"); pos != code.npos && (code.size() <= pos + 4 || !(isalnum(code[pos + 4]) || strchr("_@$", code[pos + 4]))) && (pos == 0 || !(isalnum(code[pos - 1]) || strchr("_@$", code[pos - 1])))) {
+            auto &indatt = prim->verts.add_attr<float>("IND");
+            for (size_t i = 0; i < indatt.size(); i++) indatt[i] = float(i);
+        }
+        if (auto pos = code.find("@@IND"); pos != code.npos && (code.size() <= pos + 4 || !(isalnum(code[pos + 4]) || strchr("_@$", code[pos + 4]))) && (pos == 0 || !(isalnum(code[pos - 1]) || strchr("_@$", code[pos - 1])))) {
+            auto &indatt = primNei->verts.add_attr<float>("IND");
+            for (size_t i = 0; i < indatt.size(); i++) indatt[i] = float(i);
+        }
+        // END张心欣快乐自动加@IND
+
+    zfx::Options opts(zfx::Options::for_x64);
+    opts.detect_new_symbols = true;
+    prim->foreach_attr([&](auto const &key, auto const &attr) {
+      int dim = ([](auto const &v) {
+        using T = std::decay_t<decltype(v[0])>;
+        if constexpr (std::is_same_v<T, zeno::vec3f>)
+          return 3;
+        else if constexpr (std::is_same_v<T, float>)
+          return 1;
+        else
+          return 0;
+      })(attr);
+      dbg_printf("define symbol: @%s dim %d\n", key.c_str(), dim);
+      opts.define_symbol('@' + key, dim);
+    });
+    primNei->foreach_attr([&](auto const &key, auto const &attr) {
+      int dim = ([](auto const &v) {
+        using T = std::decay_t<decltype(v[0])>;
+        if constexpr (std::is_same_v<T, zeno::vec3f>)
+          return 3;
+        else if constexpr (std::is_same_v<T, float>)
+          return 1;
+        else
+          return 0;
+      })(attr);
+      dbg_printf("define symbol: @@%s dim %d\n", key.c_str(), dim);
+      opts.define_symbol("@@" + key, dim);
+    });
+
+    auto params = has_input("params") ? get_input<zeno::DictObject>("params")
+                                      : std::make_shared<zeno::DictObject>();
+    {
+        // BEGIN心欣你也可以把这段代码加到其他wrangle节点去，这样这些wrangle也可以自动有$F$DT$T做参数
+        auto const &gs = *this->getGlobalState();
+        params->lut["PI"] = objectFromLiterial((float)(std::atan(1.f) * 4));
+        params->lut["F"] = objectFromLiterial((float)gs.frameid);
+        params->lut["DT"] = objectFromLiterial(gs.frame_time);
+        params->lut["T"] = objectFromLiterial(gs.frame_time * gs.frameid + gs.frame_time_elapsed);
+        // END心欣你也可以把这段代码加到其他wrangle节点去，这样这些wrangle也可以自动有$F$DT$T做参数
+        // BEGIN心欣你也可以把这段代码加到其他wrangle节点去，这样这些wrangle也可以自动引用portal做参数
+        for (auto const &[key, ref]: getThisGraph()->portalIns) {
+            if (auto i = code.find('$' + key); i != std::string::npos) {
+                i = i + key.size() + 1;
+                if (code.size() <= i || !std::isalnum(code[i])) {
+                    if (params->lut.count(key)) continue;
+                    dbg_printf("ref portal %s\n", key.c_str());
+                    auto res = getThisGraph()->callTempNode("PortalOut",
+                          {{"name:", objectFromLiterial(key)}}).at("port");
+                    params->lut[key] = std::move(res);
+                }
+            }
+        }
+        // END心欣你也可以把这段代码加到其他wrangle节点去，这样这些wrangle也可以自动引用portal做参数
+        // BEGIN伺候心欣伺候懒得extract出变量了
+        std::vector<std::string> keys;
+        for (auto const &[key, val]: params->lut) {
+            keys.push_back(key);
+        }
+        for (auto const &key: keys) {
+            if (!dynamic_cast<zeno::NumericObject*>(params->lut.at(key).get())) {
+                dbg_printf("ignored non-numeric %s\n", key.c_str());
+                params->lut.erase(key);
+            }
+        }
+        // END伺候心欣伺候懒得extract出变量了
+        }
+    std::vector<float> parvals;
+    std::vector<std::pair<std::string, int>> parnames;
+    for (auto const &[key_, par]: params->getLiterial<zeno::NumericValue>()) {
+            auto key = '$' + key_;
+                auto dim = std::visit([&] (auto const &v) {
+                    using T = std::decay_t<decltype(v)>;
+                    if constexpr (std::is_convertible_v<T, zeno::vec3f>) {
+                        parvals.push_back(v[0]);
+                        parvals.push_back(v[1]);
+                        parvals.push_back(v[2]);
+                        parnames.emplace_back(key, 0);
+                        parnames.emplace_back(key, 1);
+                        parnames.emplace_back(key, 2);
+                        return 3;
+                    } else if constexpr (std::is_convertible_v<T, float>) {
+                        parvals.push_back(v);
+                        parnames.emplace_back(key, 0);
+                        return 1;
+                    } else if constexpr (std::is_convertible_v<T, zeno::vec2f>) {
+                        parvals.push_back(v[0]);
+                        parvals.push_back(v[1]);
+                        parnames.emplace_back(key, 0);
+                        parnames.emplace_back(key, 1);
+                        return 2;
+                    } else {
+                        printf("invalid parameter type encountered: `%s`\n",
+                                typeid(T).name());
+                        return 0;
+                    }
+                }, par);
+                dbg_printf("define param: %s dim %d\n", key.c_str(), dim);
+                opts.define_param(key, dim);
+            //auto par = zeno::safe_any_cast<zeno::NumericValue>(obj);
+            
+        }
+
+    auto prog = compiler.compile(code, opts);
+    auto exec = assembler.assemble(prog->assembly);
+
+    for (auto const &[name, dim] : prog->newsyms) {
+      dbg_printf("auto-defined new attribute: %s with dim %d\n", name.c_str(),
+                 dim);
+      assert(name[0] == '@');
+      if (name[1] == '@') {
+        dbg_printf("ERROR: cannot define new attribute %s on primNei\n",
+                   name.c_str());
+      }
+      auto key = name.substr(1);
+      if (dim == 3) {
+        prim->add_attr<zeno::vec3f>(key);
+      } else if (dim == 1) {
+        prim->add_attr<float>(key);
+      } else {
+        dbg_printf("ERROR: bad attribute dimension for primitive: %d\n", dim);
+        abort();
+      }
+    }
+
+    for (int i = 0; i < prog->params.size(); i++) {
+      auto [name, dimid] = prog->params[i];
+      dbg_printf("parameter %d: %s.%d\n", i, name.c_str(), dimid);
+      assert(name[0] == '$');
+      auto it =
+          std::find(parnames.begin(), parnames.end(), std::pair{name, dimid});
+      auto value = parvals.at(it - parnames.begin());
+      dbg_printf("(valued %f)\n", value);
+      exec->parameter(prog->param_id(name, dimid)) = value;
+    }
+
+    std::vector<Buffer> chs(prog->symbols.size());
+    for (int i = 0; i < chs.size(); i++) {
+      auto [name, dimid] = prog->symbols[i];
+      dbg_printf("channel %d: %s.%d\n", i, name.c_str(), dimid);
+      assert(name[0] == '@');
+      Buffer iob;
+      zeno::PrimitiveObject *primPtr;
+      if (name[1] == '@') {
+        name = name.substr(2);
+        primPtr = primNei.get();
+        iob.which = 1;
+      } else {
+        name = name.substr(1);
+        primPtr = prim.get();
+        iob.which = 0;
+      }
+      prim->attr_visit(name, [&, dimid_ = dimid](auto const &arr) {
+        iob.base = (float *)arr.data() + dimid_;
+        iob.count = arr.size();
+        iob.stride = sizeof(arr[0]) / sizeof(float);
+      });
+      chs[i] = iob;
+    }
+    std::vector<Buffer> chs2(prog->symbols.size());
+    for (int i = 0; i < chs2.size(); i++) {
+      auto [name, dimid] = prog->symbols[i];
+      dbg_printf("channel %d: %s.%d\n", i, name.c_str(), dimid);
+      assert(name[0] == '@');
+      Buffer iob;
+      zeno::PrimitiveObject *primPtr;
+      if (name[1] == '@') {
+        name = name.substr(2);
+        primPtr = primNei.get();
+        iob.which = 1;
+      } else {
+        name = name.substr(1);
+        primPtr = prim.get();
+        iob.which = 0;
+      }
+      primNei->attr_visit(name, [&, dimid_ = dimid](auto const &arr) {
+        iob.base = (float *)arr.data() + dimid_;
+        iob.count = arr.size();
+        iob.stride = sizeof(arr[0]) / sizeof(float);
+      });
+      chs2[i] = iob;
+    }
+    bvh_vectors_wrangle_radius(exec, chs, chs2, prim->attr<zeno::vec3f>("pos"), radiusAttr == "" ? std::vector<float>(prim->verts.size(), 0.0f) : prim->verts.attr<float>(radiusAttr),
+                        primNei->attr<zeno::vec3f>("pos"), get_input2<bool>("is_box"),
+                        lbvh.get()->thickness * lbvh.get()->thickness, lbvh.get());
+
+    set_output("prim", std::move(prim));
+  }
+};
+
+ZENDEFNODE(ParticlesNeighborBvhRadiusWrangle,
+           {
+               {{"PrimitiveObject", "prim"},
+                {"PrimitiveObject", "primNei"},
+                {"LBvh", "lbvh"},
+                {"bool", "is_box", "0"},
+                {"string", "radiusAttr", "radius"},
+                {"string", "zfxCode"},
+                {"DictObject:NumericObject", "params"}},
+               {{"PrimitiveObject", "prim"}},
+               {},
+               {"zenofx"},
+           });
+
+
+
 
 } // namespace


### PR DESCRIPTION
![image](https://github.com/zenustech/zeno/assets/83103239/7c279051-1727-4dc3-9834-5904b4e23ba9)
新增两个节点  可根据vert上的半径属性查找邻域  radiusAttr为空就和正常neighborBvhWrangle行为一样