### PR TITLE
integrate light panel into param panel

### DIFF
--- a/ui/zenoedit/dock/ztabdockwidget.cpp
+++ b/ui/zenoedit/dock/ztabdockwidget.cpp
@@ -518,7 +518,7 @@ void ZTabDockWidget::onAddTabClicked()
     font.setBold(false);
     menu->setFont(font);
 
-    static QList<QString> panels = { tr("Parameter"), tr("Scene Viewport"), tr("Node Editor"), tr("Spreadsheet"), tr("Log"), tr("Light"), tr("Image"), tr("Optix") };
+    static QList<QString> panels = { tr("Parameter"), tr("Scene Viewport"), tr("Node Editor"), tr("Spreadsheet"), tr("Log"), tr("Image"), tr("Optix") };
     for (QString name : panels)
     {
         QAction* pAction = new QAction(name);

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -329,7 +329,7 @@ QGraphicsItem* ZenoNode::initParamWidget(ZenoSubGraphScene* scene, const QModelI
         pModel->ModelSetData(perIdx, newValue, ROLE_PARAM_VALUE);
     };
     auto cbUpdateSocketDefldWithSlider = [=](QVariant newValue) {
-        AppHelper::socketEditFinishedWithSlider(newValue, m_index, perIdx);
+        AppHelper::modifyOptixObjDirectly(newValue, m_index, perIdx);
     };
 
     auto cbSwith = [=](bool bOn) {
@@ -1165,7 +1165,7 @@ QGraphicsItem* ZenoNode::initSocketWidget(ZenoSubGraphScene* scene, const QModel
         AppHelper::socketEditFinished(newValue, m_index, perIdx);
     };
     auto cbUpdateSocketDefldWithSlider = [=](QVariant newValue) {
-        AppHelper::socketEditFinishedWithSlider(newValue, m_index, perIdx);
+        AppHelper::modifyOptixObjDirectly(newValue, m_index, perIdx);
     };
 
     auto cbSwith = [=](bool bOn) {

--- a/ui/zenoedit/panel/zenoproppanel.cpp
+++ b/ui/zenoedit/panel/zenoproppanel.cpp
@@ -343,6 +343,7 @@ bool ZenoPropPanel::syncAddControl(ZExpandableSection* pGroupWidget, QGridLayout
             }
         }
         AppHelper::socketEditFinished(newValue, m_idx, perIdx);
+        AppHelper::modifyOptixObjDirectly(newValue, m_idx, perIdx, true);
     };
     cbSet.cbSwitch = [=](bool bOn) {
         zenoApp->getMainWindow()->setInDlgEventLoop(bOn);   //deal with ubuntu dialog slow problem when update viewport.

--- a/ui/zenoedit/util/apphelper.h
+++ b/ui/zenoedit/util/apphelper.h
@@ -24,7 +24,8 @@ public:
     static void ensureSRCDSTlastKey(INPUT_SOCKETS& inputs, OUTPUT_SOCKETS& outputs);
     static QString nativeWindowTitle(const QString& currentFilePath);
     static void socketEditFinished(QVariant newValue, QPersistentModelIndex nodeIdx, QPersistentModelIndex paramIdx);
-    static void socketEditFinishedWithSlider(QVariant newValue, QPersistentModelIndex nodeIdx, QPersistentModelIndex paramIdx);
+    static void modifyOptixObjDirectly(QVariant newValue, QPersistentModelIndex nodeIdx, QPersistentModelIndex paramIdx, bool editByPropPanel = false);
+    static void modifyOptixCameraPropDirectly(QVariant newValue, QPersistentModelIndex nodeIdx, QPersistentModelIndex paramIdx);
     static void modifyLightData(QVariant newValue, QPersistentModelIndex nodeIdx, QPersistentModelIndex paramIdx);
     static VideoRecInfo getRecordInfo(const ZENO_RECORD_RUN_INITPARAM& param);
     static void initLaunchCacheParam(LAUNCH_PARAM& param);

--- a/ui/zenoedit/viewport/optixviewport.h
+++ b/ui/zenoedit/viewport/optixviewport.h
@@ -3,6 +3,7 @@
 
 #include <QtWidgets>
 #include "recordvideomgr.h"
+#include <zenomodel/include/modeldata.h>
 
 class Zenovis;
 class CameraControl;
@@ -37,6 +38,8 @@ public slots:
     bool recordFrame_impl(VideoRecInfo recInfo, int frame);
     void onSetLoopPlaying(bool enbale);
     void onSetSlidFeq(int feq);
+    void onModifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString nodename, UI_VECTYPE skipParam);
+    void onUpdateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam = UI_VECTYPE());
 
 private:
     Zenovis *m_zenoVis;
@@ -73,6 +76,7 @@ public:
     void cancelRecording(VideoRecInfo recInfo);
     void killThread();
     void setSlidFeq(int feq);
+    void modifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString name, UI_VECTYPE skipParam);
 
 signals:
     void cameraAboutToRefresh();
@@ -90,6 +94,8 @@ signals:
     void sig_setLoopPlaying(bool enable);
     void sig_setSlidFeq(int feq);
     void sigscreenshoot(QString, QString, int, int);
+    void sig_modifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString name, UI_VECTYPE skipParam);
+    void sig_updateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam = UI_VECTYPE());
 
 public slots:
     void onFrameRunFinished(int frame);

--- a/ui/zenoui/comctrl/zlineedit.cpp
+++ b/ui/zenoui/comctrl/zlineedit.cpp
@@ -31,6 +31,7 @@ ZLineEdit::ZLineEdit(const QString& text, QWidget* parent)
 void ZLineEdit::init()
 {
     connect(this, SIGNAL(editingFinished()), this, SIGNAL(textEditFinished()));
+    connect(this, &ZLineEdit::textChanged, this, &ZLineEdit::editingFinished);
 }
 
 void ZLineEdit::setShowingSlider(bool bShow)
@@ -71,6 +72,7 @@ void ZLineEdit::setNumSlider(const QVector<qreal>& steps)
             num = num + val;
             QString newText = QString::number(num);
             setText(newText);
+            emit editingFinished();
         }
     });
     connect(m_pSlider, &ZNumSlider::slideFinished, this, [=]() {


### PR DESCRIPTION
1. integrate light panel into param panel, then disable ZenoLights panel, can preview lightnode and CameraNode, MakeCamera, TargetCamera(only aperture and distancePlane)
2. disable modifying parameters of procedure sky through param panel, because it's deprecated