### PR TITLE
Update BUILD.md: Fix parallel course link

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -110,7 +110,7 @@ cd zeno
 
 ## Build Zeno
 
-Quickly recall our CMake knowledge in [my parallel course](github.com/parallel101/course):
+Quickly recall our CMake knowledge in [my parallel course](https://github.com/parallel101/course):
 
 1. The first step `cmake -B build` called *configure*, it generates the `build/` directory containing `Makefile`.
 2. The second step `cmake --build build` called *build*, equivalant to `make -C build` on Linux and call MSBuild on Windows.


### PR DESCRIPTION
Hi there, I was checking the instructions for building Zeno, and found there's a missing link - `my parallel course` will lead to a page with 404. I guess the link is missing the `https://` prefix so I added it there.
![image](https://github.com/zenustech/zeno/assets/16759982/e346de1c-ed10-415e-8c7b-e06a0268a8e1)
