### PR TITLE
Isolate cache objs

### DIFF
--- a/ui/zenoedit/cache/zcachemgr.cpp
+++ b/ui/zenoedit/cache/zcachemgr.cpp
@@ -17,8 +17,9 @@ bool ZCacheMgr::initCacheDir(bool bTempDir, QDir dirCacheRoot, bool bAutoCleanCa
 {
     clearNotUsedToViewCache();
 
-    if (!m_isNew)
+    if (nextRunSkipCreateDir(bTempDir)) {
         return true;
+    }
 
     if (bTempDir || bAutoCleanCache)
         cleanCacheDir();
@@ -140,6 +141,18 @@ bool ZCacheMgr::hasCacheOnly(QDir dir, bool& empty)
 void ZCacheMgr::removeObjTmpCacheDir()
 {
     m_objTmpCacheDir.remove();
+}
+
+bool ZCacheMgr::nextRunSkipCreateDir(bool tmpDir)
+{
+    if (m_bTempDir != tmpDir)
+    {
+        return false;
+    }
+    else if(m_isNew || !lastRunCachePath.exists()) {
+        return false;
+    }
+    return true;
 }
 
 void ZCacheMgr::clearNotUsedToViewCache()

--- a/ui/zenoedit/cache/zcachemgr.cpp
+++ b/ui/zenoedit/cache/zcachemgr.cpp
@@ -9,7 +9,6 @@
 ZCacheMgr::ZCacheMgr()
     : m_bTempDir(true)
     , m_isNew(true)
-    , m_cacheOpt(Opt_Undefined)
 {
     m_objTmpCacheDir.setAutoRemove(true);
 }
@@ -17,15 +16,12 @@ ZCacheMgr::ZCacheMgr()
 bool ZCacheMgr::initCacheDir(bool bTempDir, QDir dirCacheRoot, bool bAutoCleanCache)
 {
     clearNotUsedToViewCache();
-    if (!m_isNew && (m_cacheOpt == Opt_RunLightCameraMaterial || m_cacheOpt == Opt_AlwaysOn)) {
-         return true;
-    }
-    if ((bTempDir || bAutoCleanCache) &&
-            m_cacheOpt != Opt_RunLightCameraMaterial &&
-            m_cacheOpt != Opt_AlwaysOn)
-    {
+
+    if (!m_isNew)
+        return true;
+
+    if (bTempDir || bAutoCleanCache)
         cleanCacheDir();
-    }
 
     m_bTempDir = bTempDir;
     if (m_bTempDir) {
@@ -82,21 +78,12 @@ QDir ZCacheMgr::getPersistenceDir() const
     return m_spCacheDir;
 }
 
-
-void ZCacheMgr::setCacheOpt(cacheOption opt) {
-    m_cacheOpt = opt;
-}
-
 void ZCacheMgr::setNewCacheDir(bool setNew) {
     m_isNew = setNew;
     if (m_isNew)
     {
         removeObjTmpCacheDir();
     }
-}
-
-ZCacheMgr::cacheOption ZCacheMgr::getCacheOption() {
-    return m_cacheOpt;
 }
 
 void ZCacheMgr::cleanCacheDir()
@@ -167,6 +154,12 @@ void ZCacheMgr::clearNotUsedToViewCache()
         const QModelIndex& idx = pModel->index(i, subgIdx);
         if (idx.data(ROLE_OPTIONS).toInt() & OPT_VIEW)
             newToViewNodes.insert(idx.data(ROLE_OBJID).toString());
+    }
+
+    if (m_isNew)
+    {
+        lastRunToViewNodes.swap(newToViewNodes);
+        return;
     }
 
     QVector<QString> toViewCachesToBeRemoved;

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -2,6 +2,7 @@
 #define __ZCACHEMGR_H__
 
 #include <QtWidgets>
+#include "launch/corelaunch.h"
 
 class ZCacheMgr
 {
@@ -17,6 +18,7 @@ public:
     void cleanCacheDir();
     bool hasCacheOnly(QDir dir, bool& empty);
     void removeObjTmpCacheDir();
+    bool nextRunSkipCreateDir(bool tmpDir);
 
 private:
     void clearNotUsedToViewCache();

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -8,7 +8,7 @@ class ZCacheMgr
 {
 public:
     ZCacheMgr();
-    bool initCacheDir(bool bTempDir, QDir dir, bool bAutoCleanCache);
+    bool initCacheDir(QDir dir, LAUNCH_PARAM& param);
     QString cachePath() const;
     QString objCachePath() const;
     std::shared_ptr<QTemporaryDir> getTempDir() const;
@@ -18,7 +18,7 @@ public:
     void cleanCacheDir();
     bool hasCacheOnly(QDir dir, bool& empty);
     void removeObjTmpCacheDir();
-    bool nextRunSkipCreateDir(bool tmpDir);
+    bool nextRunSkipCreateDir(LAUNCH_PARAM& param);
 
 private:
     void clearNotUsedToViewCache();

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -13,28 +13,20 @@ public:
     std::shared_ptr<QTemporaryDir> getTempDir() const;
     QDir getPersistenceDir() const;
 
-    enum cacheOption {
-        Opt_Undefined = 0,
-        Opt_RunAll,
-        Opt_RunLightCameraMaterial,
-        Opt_AlwaysOn
-    };
-    void setCacheOpt(cacheOption opt);
     void setNewCacheDir(bool setNew);
-    cacheOption getCacheOption();
     void cleanCacheDir();
     bool hasCacheOnly(QDir dir, bool& empty);
     void removeObjTmpCacheDir();
-    void clearNotUsedToViewCache();
 
 private:
+    void clearNotUsedToViewCache();
+
     QTemporaryDir m_objTmpCacheDir;
     std::shared_ptr<QTemporaryDir> m_spTmpCacheDir;
     QDir m_spCacheDir;
     bool m_bTempDir;
 
     bool m_isNew;
-    cacheOption m_cacheOpt;
 
     QDir lastRunCachePath;
 

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -20,8 +20,10 @@ public:
     void removeObjTmpCacheDir();
     bool nextRunSkipCreateDir(LAUNCH_PARAM& param);
 
+    bool nodeCacheExist(QString& id);
+
 private:
-    void clearNotUsedToViewCache();
+    void initToViewNodesId();
 
     QTemporaryDir m_objTmpCacheDir;
     std::shared_ptr<QTemporaryDir> m_spTmpCacheDir;
@@ -31,8 +33,6 @@ private:
     bool m_isNew;
 
     QDir lastRunCachePath;
-
-    QSet<QString> lastRunToViewNodes;
 };
 
 #endif

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -25,6 +25,7 @@ public:
     void cleanCacheDir();
     bool hasCacheOnly(QDir dir, bool& empty);
     void removeObjTmpCacheDir();
+    void clearNotUsedToViewCache();
 
 private:
     QTemporaryDir m_objTmpCacheDir;
@@ -36,6 +37,8 @@ private:
     cacheOption m_cacheOpt;
 
     QDir lastRunCachePath;
+
+    QSet<QString> lastRunToViewNodes;
 };
 
 #endif

--- a/ui/zenoedit/dock/docktabcontent.cpp
+++ b/ui/zenoedit/dock/docktabcontent.cpp
@@ -886,7 +886,7 @@ void DockContent_View::initConnections()
             ZASSERT_EXIT(session);
             auto scene = session->get_scene();
             ZASSERT_EXIT(scene);
-            zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
+            zeno::getSession().globalComm->setNeedUpdateLight(true);
             m_pDisplay->setSimpleRenderOption();
             zenoApp->getMainWindow()->updateViewport();
         }

--- a/ui/zenoedit/dock/docktabcontent.cpp
+++ b/ui/zenoedit/dock/docktabcontent.cpp
@@ -27,8 +27,10 @@
 #include <zenoui/comctrl/zcombobox.h>
 #include <zeno/core/Session.h>
 #include <zeno/types/UserData.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenoui/comctrl/ztoolmenubutton.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 ZToolBarButton::ZToolBarButton(bool bCheckable, const QString& icon, const QString& iconOn)
@@ -884,7 +886,7 @@ void DockContent_View::initConnections()
             ZASSERT_EXIT(session);
             auto scene = session->get_scene();
             ZASSERT_EXIT(scene);
-            scene->objectsMan->needUpdateLight = true;
+            zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
             m_pDisplay->setSimpleRenderOption();
             zenoApp->getMainWindow()->updateViewport();
         }

--- a/ui/zenoedit/dock/docktabcontent.cpp
+++ b/ui/zenoedit/dock/docktabcontent.cpp
@@ -319,9 +319,6 @@ void DockContent_Editor::initToolbar(QHBoxLayout* pToolLayout)
     pAlways->setToolTip(tr("Always mode"));
 
     m_btnRun = new ZToolMenuButton(this);
-    m_btnRun->addAction(tr("Run"), ":/icons/run_all.svg");
-    m_btnRun->addAction(tr("RunLightCamera"), ":/icons/run_lightcamera.svg");
-    m_btnRun->addAction(tr("RunMaterial"), ":/icons/run_material.svg");
     m_btnKill = new ZTextIconButton(tr("Running..."), this);
 
     QFont fnt = QApplication::font();
@@ -474,7 +471,6 @@ void DockContent_Editor::initConnections()
     std::function<void()> resetAlways = [=]() {
         pAlways->setChecked(false);
         pMainWin->setAlways(false);
-        pMainWin->setAlwaysLightCameraMaterial(false, false);
     };
     connect(zenoApp->graphsManagment(), &GraphsManagment::fileOpened, this, resetAlways);
     connect(zenoApp->graphsManagment(), &GraphsManagment::modelInited, this, resetAlways);
@@ -492,22 +488,10 @@ void DockContent_Editor::initConnections()
                     displayWid->setRenderSeparately(false, false);
                 }
             }
-            if (m_btnRun->text() == tr("Run"))
-            {
-                pMainWin->setAlways(true);
-                pMainWin->setAlwaysLightCameraMaterial(false, false);
-            }
-            else {
-                if (m_btnRun->text() == tr("RunLightCamera"))
-                    pMainWin->setAlwaysLightCameraMaterial(true, false);
-                else if (m_btnRun->text() == tr("RunMaterial"))
-                    pMainWin->setAlwaysLightCameraMaterial(false, true);
-                pMainWin->setAlways(false);
-            }
+            pMainWin->setAlways(true);
         }
         else {
             pMainWin->setAlways(false);
-            pMainWin->setAlwaysLightCameraMaterial(false, false);
         }
     });
     connect(m_pEditor, &ZenoGraphsEditor::zoomed, [=](qreal newFactor) {
@@ -536,8 +520,6 @@ void DockContent_Editor::initConnections()
             return;
         m_btnRun->setVisible(false);
         m_btnKill->setVisible(true);
-        std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
-        ZASSERT_EXIT(mgr);
         ZenoMainWindow *pMainWin = zenoApp->getMainWindow();
         ZASSERT_EXIT(pMainWin);
         std::function<void(bool, bool)> setOptixUpdateSeparately = [=](bool updateLightCameraOnly, bool updateMatlOnly) {
@@ -548,61 +530,10 @@ void DockContent_Editor::initConnections()
                 }
             }
         };
-        if (m_btnRun->text() == tr("Run"))
-        {
-            setOptixUpdateSeparately(false, false);
-            mgr->setCacheOpt(ZCacheMgr::Opt_RunAll);
-            pMainWin->onRunTriggered();
-        }
-        else {
-            QSettings settings(zsCompanyName, zsEditor);
-            if (!settings.value("zencache-enable").toBool()) {
-                QMessageBox::warning(nullptr, tr("RunLightCamera"), tr("This function can only be used in cache mode."));
-            } else {
-                mgr->setCacheOpt(ZCacheMgr::Opt_RunLightCameraMaterial);
-                if (m_btnRun->text() == tr("RunLightCamera"))
-                {
-                    setOptixUpdateSeparately(true, false);
-                    pMainWin->onRunTriggered(true, false);
-                }
-                if (m_btnRun->text() == tr("RunMaterial"))
-                {
-                    setOptixUpdateSeparately(false, true);
-                    pMainWin->onRunTriggered(false, true);
-                }
-            }
-        }
+        setOptixUpdateSeparately(false, false);
+        pMainWin->onRunTriggered();
     });
 
-    connect(m_btnRun, &ZToolMenuButton::textChanged, this, [=]() {
-        if (pAlways->isChecked())
-            pAlways->setChecked(false);
-        QString text = m_btnRun->text();
-        QColor clr;
-        QColor hoverClr;
-        if (text == tr("Run"))
-        {
-            clr = QColor("#1978E6");
-            hoverClr = QColor("#599EED");
-            m_btnRun->setIcon(ZenoStyle::dpiScaledSize(QSize(16, 16)), ":/icons/run_all_btn.svg",
-                ":/icons/run_all_btn.svg", "", "");
-        }
-        else if (text == tr("RunLightCamera"))
-        {
-            clr = QColor("#E67B19");
-            hoverClr = QColor("#EDA059");
-            m_btnRun->setIcon(ZenoStyle::dpiScaledSize(QSize(16, 16)), ":/icons/run_lightcamera_btn.svg",
-                ":/icons/run_lightcamera_btn.svg", "", "");
-        }
-        else if (text == tr("RunMaterial"))
-        {
-            clr = QColor("#BD19E6");
-            hoverClr = QColor("#CF59ED");
-            m_btnRun->setIcon(ZenoStyle::dpiScaledSize(QSize(16, 16)), ":/icons/run_material_btn.svg",
-                ":/icons/run_material_btn.svg", "", "");
-        }
-        m_btnRun->setBackgroundClr(clr, hoverClr, clr, clr);
-    });
     connect(m_btnKill, &ZTextIconButton::clicked, this, [=]() {
         killProgram();
         m_btnRun->setVisible(true);

--- a/ui/zenoedit/dock/ztabdockwidget.cpp
+++ b/ui/zenoedit/dock/ztabdockwidget.cpp
@@ -316,11 +316,10 @@ void ZTabDockWidget::onNodesSelected(const QModelIndex& subgIdx, const QModelInd
                     auto *scene = pZenoVis->getSession()->get_scene();
                     scene->selected.clear();
                     std::string nodeid = nodeId.toStdString();
-                    for (auto const &[key, ptr] : zeno::getSession().globalComm->objectsMan->pairs()) {
-                        if (nodeid == key.substr(0, key.find_first_of(':'))) {
-                            scene->selected.insert(key);
-                        }
-                    }
+
+                    auto& key = zeno::getSession().globalComm->getObjKeyByObjID(nodeid);
+                    if (key != "")
+                        scene->selected.insert(key);
                     onPrimitiveSelected(scene->selected);
                 }
             }

--- a/ui/zenoedit/dock/ztabdockwidget.cpp
+++ b/ui/zenoedit/dock/ztabdockwidget.cpp
@@ -17,10 +17,12 @@
 #include <zenoui/style/zenostyle.h>
 #include <zenoui/comctrl/zicontoolbutton.h>
 #include <zenomodel/include/modelrole.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenomodel/include/uihelper.h>
 #include "util/apphelper.h"
 #include "viewport/optixviewport.h"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 #include "launch/ztcpserver.h"
 
@@ -314,7 +316,7 @@ void ZTabDockWidget::onNodesSelected(const QModelIndex& subgIdx, const QModelInd
                     auto *scene = pZenoVis->getSession()->get_scene();
                     scene->selected.clear();
                     std::string nodeid = nodeId.toStdString();
-                    for (auto const &[key, ptr] : scene->objectsMan->pairs()) {
+                    for (auto const &[key, ptr] : zeno::getSession().globalComm->objectsMan->pairs()) {
                         if (nodeid == key.substr(0, key.find_first_of(':'))) {
                             scene->selected.insert(key);
                         }

--- a/ui/zenoedit/launch/corelaunch.cpp
+++ b/ui/zenoedit/launch/corelaunch.cpp
@@ -246,6 +246,7 @@ void launchProgram(IGraphsModel* pModel, LAUNCH_PARAM param)
 	RAPIDJSON_WRITER writer(s);
     {
         JsonArrayBatch batch(writer);
+        JsonHelper::AddVariantList({ "runDirtyNodesOnly", param.runDirtyNodesOnly }, "bool",  writer);
         JsonHelper::AddVariantList({"setBeginFrameNumber", param.beginFrame}, "int", writer);
         JsonHelper::AddVariantList({"setEndFrameNumber", param.endFrame}, "int", writer);
         serializeScene(pModel, writer, param.paramPath);

--- a/ui/zenoedit/launch/corelaunch.cpp
+++ b/ui/zenoedit/launch/corelaunch.cpp
@@ -248,7 +248,7 @@ void launchProgram(IGraphsModel* pModel, LAUNCH_PARAM param)
         JsonArrayBatch batch(writer);
         JsonHelper::AddVariantList({"setBeginFrameNumber", param.beginFrame}, "int", writer);
         JsonHelper::AddVariantList({"setEndFrameNumber", param.endFrame}, "int", writer);
-        serializeScene(pModel, writer, param.applyLightAndCameraOnly, param.applyMaterialOnly, param.paramPath);
+        serializeScene(pModel, writer, param.paramPath);
     }
     std::string progJson(s.GetString());
 #ifdef DEBUG_SERIALIZE

--- a/ui/zenoedit/launch/corelaunch.cpp
+++ b/ui/zenoedit/launch/corelaunch.cpp
@@ -246,7 +246,6 @@ void launchProgram(IGraphsModel* pModel, LAUNCH_PARAM param)
 	RAPIDJSON_WRITER writer(s);
     {
         JsonArrayBatch batch(writer);
-        JsonHelper::AddVariantList({ "runDirtyNodesOnly", param.runDirtyNodesOnly }, "bool",  writer);
         JsonHelper::AddVariantList({"setBeginFrameNumber", param.beginFrame}, "int", writer);
         JsonHelper::AddVariantList({"setEndFrameNumber", param.endFrame}, "int", writer);
         serializeScene(pModel, writer, param.paramPath);

--- a/ui/zenoedit/launch/corelaunch.h
+++ b/ui/zenoedit/launch/corelaunch.h
@@ -19,8 +19,6 @@ struct LAUNCH_PARAM {
     QString zsgPath;
     int projectFps = 24;
     QString paramPath;
-
-    bool runDirtyNodesOnly = true;
 };
 
 void launchProgram(IGraphsModel *pModel, LAUNCH_PARAM param);

--- a/ui/zenoedit/launch/corelaunch.h
+++ b/ui/zenoedit/launch/corelaunch.h
@@ -8,8 +8,6 @@ class IGraphsModel;
 struct LAUNCH_PARAM {
     int beginFrame = 0;
     int endFrame = 0;
-    bool applyLightAndCameraOnly = false;
-    bool applyMaterialOnly = false;
 
     bool enableCache = false;
     bool tempDir = false;

--- a/ui/zenoedit/launch/corelaunch.h
+++ b/ui/zenoedit/launch/corelaunch.h
@@ -19,6 +19,8 @@ struct LAUNCH_PARAM {
     QString zsgPath;
     int projectFps = 24;
     QString paramPath;
+
+    bool runDirtyNodesOnly = true;
 };
 
 void launchProgram(IGraphsModel *pModel, LAUNCH_PARAM param);

--- a/ui/zenoedit/launch/runnermain.cpp
+++ b/ui/zenoedit/launch/runnermain.cpp
@@ -161,7 +161,7 @@ static int runner_start(std::string const &progJson, int sessionid, const LAUNCH
             QLockFile lckFile(QString::fromStdString(sLockFile));
             bool ret = lckFile.tryLock();
             //dump cache to disk.
-            session->globalComm->dumpFrameCache(frame, param.applyLightAndCameraOnly, param.applyMaterialOnly);
+            session->globalComm->dumpFrameCache(frame);
         } else {
             auto const& viewObjs = session->globalComm->getViewObjects();
             zeno::log_debug("runner got {} view objects", viewObjs.size());
@@ -202,8 +202,6 @@ int runner_main(const QCoreApplication& app) {
         {"enablecache", "enablecache", "enable zencache"},
         {"cachenum", "cachenum", "max cached frames"},
         {"cachedir", "cachedir", "cache dir for this run"},
-        {"cacheLightCameraOnly", "cacheLightCameraOnly", "only cache light and camera object"},
-        {"cacheMaterialOnly", "cacheMaterialOnly", "only cache material object"},
         {"cacheautorm", "cacheautoremove", "remove cache after render"},
         {"zsg", "zsg", "zsg"},
         {"projectFps", "current project fps", "fps"},
@@ -222,10 +220,6 @@ int runner_main(const QCoreApplication& app) {
         param.cacheDir = cmdParser.value("cachedir");
     if (cmdParser.isSet("objcachedir"))
         param.objCacheDir = cmdParser.value("objcachedir");
-    if (cmdParser.isSet("cacheLightCameraOnly"))
-        param.applyLightAndCameraOnly = cmdParser.value("cacheLightCameraOnly").toInt();
-    if (cmdParser.isSet("cacheMaterialOnly"))
-        param.applyMaterialOnly = cmdParser.value("cacheMaterialOnly").toInt();
     if (cmdParser.isSet("cacheautorm"))
         param.autoRmCurcache = cmdParser.value("cacheautorm").toInt();
     if (cmdParser.isSet("zsg"))

--- a/ui/zenoedit/launch/serialize.cpp
+++ b/ui/zenoedit/launch/serialize.cpp
@@ -11,12 +11,6 @@
 
 using namespace JsonHelper;
 
-QSet<QString> lightCameraNodes({
-    "CameraEval", "CameraNode", "CihouMayaCameraFov", "ExtractCameraData", "GetAlembicCamera","MakeCamera",
-    "LightNode", "BindLight", "ProceduralSky", "HDRSky",
-    });
-QString matlNode = "ShaderFinalize";
-
 static QString nameMangling(const QString& prefix, const QString& ident) {
     if (prefix.isEmpty())
         return ident;
@@ -112,7 +106,7 @@ static void getOptStr(const QString& sockType, QVariant& defl, QString& opStr)
     }
 }
 
-static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgIdx, QString const &graphIdPrefix, bool bView, RAPIDJSON_WRITER& writer, bool bNestedSubg = true, bool applyLightAndCameraOnly = false, bool applyMaterialOnly = false, const QString &configPath = "")
+static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgIdx, QString const &graphIdPrefix, bool bView, RAPIDJSON_WRITER& writer, bool bNestedSubg = true, const QString &configPath = "")
 {
     ZASSERT_EXIT(pGraphsModel && subgIdx.isValid());
 
@@ -178,7 +172,7 @@ static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgId
                 AddStringList({"pushSubnetScope", ident}, writer);
                 const QString& prefix = nameMangling(graphIdPrefix, idx.data(ROLE_OBJID).toString());
                 bool _bView = bView && (idx.data(ROLE_OPTIONS).toInt() & OPT_VIEW);
-                serializeGraph(pGraphsModel, pGraphsModel->index(name), prefix, _bView, writer, true, applyLightAndCameraOnly, applyMaterialOnly, configPath);
+                serializeGraph(pGraphsModel, pGraphsModel->index(name), prefix, _bView, writer, true, configPath);
                 AddStringList({"popSubnetScope", ident}, writer);
             }
         }
@@ -410,10 +404,6 @@ static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgId
             }
             else
             {
-                if ((applyLightAndCameraOnly && !lightCameraNodes.contains(name) || applyMaterialOnly && name != matlNode) && !pGraphsModel->IsSubGraphNode(idx))
-                {
-                    continue;
-                }
                 for (OUTPUT_SOCKET output : outputs)
                 {
                     //if (output.info.name == "DST" && outputs.size() > 1)
@@ -435,9 +425,9 @@ static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgId
     }
 }
 
-void serializeScene(IGraphsModel* pModel, RAPIDJSON_WRITER& writer, bool applyLightAndCameraOnly, bool applyMaterialOnly, const QString& configPath)
+void serializeScene(IGraphsModel* pModel, RAPIDJSON_WRITER& writer, const QString& configPath)
 {
-    serializeGraph(pModel, pModel->index("main"), "", true, writer, true, applyLightAndCameraOnly, applyMaterialOnly, configPath);
+    serializeGraph(pModel, pModel->index("main"), "", true, writer, true, configPath);
 }
 
 static void serializeSceneOneGraph(IGraphsModel* pModel, RAPIDJSON_WRITER& writer, QString subgName)

--- a/ui/zenoedit/launch/serialize.cpp
+++ b/ui/zenoedit/launch/serialize.cpp
@@ -389,35 +389,28 @@ static void serializeGraph(IGraphsModel* pGraphsModel, const QModelIndex& subgId
             AddStringList({"markNodeChanged", ident}, writer);
         }
 
-        AddStringList({ "completeNode", ident }, writer);
-
 		if (bView && (opts & OPT_VIEW))
         {
             if (name == "SubOutput")
             {
-                auto viewerIdent = ident + ":TOVIEW";
-                AddStringList({"addNode", "ToView", viewerIdent}, writer);
-                AddStringList({"bindNodeInput", viewerIdent, "object", ident, "_OUT_port"}, writer);
                 bool isStatic = opts & OPT_ONCE;
-                AddVariantList({"setNodeInput", viewerIdent, "isStatic", isStatic}, "int", writer);
-                AddStringList({"completeNode", viewerIdent}, writer);
+                AddVariantList({ "setToView", ident, "_OUT_port", isStatic }, "int", writer);
             }
             else
             {
                 for (OUTPUT_SOCKET output : outputs)
                 {
-                    //if (output.info.name == "DST" && outputs.size() > 1)
-                        //continue;
-                    auto viewerIdent = ident + ":TOVIEW";
-                    AddStringList({"addNode", "ToView", viewerIdent}, writer);
-                    AddStringList({"bindNodeInput", viewerIdent, "object", ident, output.info.name}, writer);
+                    ////if (output.info.name == "DST" && outputs.size() > 1)
+                    //    //continue;
                     bool isStatic = opts & OPT_ONCE;
-                    AddVariantList({"setNodeInput", viewerIdent, "isStatic", isStatic}, "int", writer);
-                    AddStringList({"completeNode", viewerIdent}, writer);
+                    AddVariantList({ "setToView", ident, output.info.name, isStatic }, "int", writer);
                     break;  //current node is not a subgraph node, so only one output is needed to view this obj.
                 }
             }
         }
+
+        AddStringList({ "completeNode", ident }, writer);
+
         if (opts & OPT_CACHE)
         {
             AddStringList({ "cacheToDisk", ident}, writer);

--- a/ui/zenoedit/launch/serialize.h
+++ b/ui/zenoedit/launch/serialize.h
@@ -7,7 +7,7 @@
 
 class IGraphsModel;
 
-void serializeScene(IGraphsModel* pModel, RAPIDJSON_WRITER& writer, bool applyLightAndCameraOnly = false, bool applyMaterialOnly = false, const QString& configPath = "");
+void serializeScene(IGraphsModel* pModel, RAPIDJSON_WRITER& writer, const QString& configPath = "");
 QString serializeSceneCpp(IGraphsModel* pModel);
 
 #endif

--- a/ui/zenoedit/launch/ztcpserver.cpp
+++ b/ui/zenoedit/launch/ztcpserver.cpp
@@ -127,7 +127,8 @@ void ZTcpServer::startProc(const std::string& progJson, LAUNCH_PARAM param)
         "--cacheautorm", QString::number(param.autoRmCurcache),
         "--zsg", param.zsgPath,
         "--projectFps", QString::number(param.projectFps),
-        "--objcachedir", zenoApp->cacheMgr()->objCachePath(),
+        //"--objcachedir", zenoApp->cacheMgr()->objCachePath(),
+        "--objcachedir", cachedir,
     };
 
     m_proc->start(QCoreApplication::applicationFilePath(), args);

--- a/ui/zenoedit/launch/ztcpserver.cpp
+++ b/ui/zenoedit/launch/ztcpserver.cpp
@@ -96,7 +96,6 @@ void ZTcpServer::startProc(const std::string& progJson, LAUNCH_PARAM param)
         }
         std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
         ZASSERT_EXIT(mgr);
-        mgr->setCacheOpt(ZCacheMgr::Opt_AlwaysOn);
         bool ret = mgr->initCacheDir(param.tempDir, cacheRootdir, param.autoCleanCacheInCacheRoot);
         ZASSERT_EXIT(ret);
         cachedir = mgr->cachePath();
@@ -125,8 +124,6 @@ void ZTcpServer::startProc(const std::string& progJson, LAUNCH_PARAM param)
         "--enablecache", QString::number(param.enableCache && QFileInfo(cachedir).isDir() && param.cacheNum),
         "--cachenum", QString::number(param.cacheNum),
         "--cachedir", cachedir,
-        "--cacheLightCameraOnly", QString::number(param.applyLightAndCameraOnly),
-        "--cacheMaterialOnly", QString::number(param.applyMaterialOnly),
         "--cacheautorm", QString::number(param.autoRmCurcache),
         "--zsg", param.zsgPath,
         "--projectFps", QString::number(param.projectFps),

--- a/ui/zenoedit/launch/ztcpserver.cpp
+++ b/ui/zenoedit/launch/ztcpserver.cpp
@@ -96,6 +96,7 @@ void ZTcpServer::startProc(const std::string& progJson, LAUNCH_PARAM param)
         }
         std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
         ZASSERT_EXIT(mgr);
+        mgr->setCacheOpt(ZCacheMgr::Opt_AlwaysOn);
         bool ret = mgr->initCacheDir(param.tempDir, cacheRootdir, param.autoCleanCacheInCacheRoot);
         ZASSERT_EXIT(ret);
         cachedir = mgr->cachePath();

--- a/ui/zenoedit/launch/ztcpserver.cpp
+++ b/ui/zenoedit/launch/ztcpserver.cpp
@@ -96,7 +96,7 @@ void ZTcpServer::startProc(const std::string& progJson, LAUNCH_PARAM param)
         }
         std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
         ZASSERT_EXIT(mgr);
-        bool ret = mgr->initCacheDir(param.tempDir, cacheRootdir, param.autoCleanCacheInCacheRoot);
+        bool ret = mgr->initCacheDir(cacheRootdir, param);
         ZASSERT_EXIT(ret);
         cachedir = mgr->cachePath();
         int cnum = param.cacheNum;

--- a/ui/zenoedit/nodesys/readfbxprim.cpp
+++ b/ui/zenoedit/nodesys/readfbxprim.cpp
@@ -7,7 +7,7 @@
 
 #include <viewport/zenovis.h>
 #include <zeno/core/Session.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/extra/GlobalState.h>
 #include <zeno/types/UserData.h>
 #include <zeno/extra/TempNode.h>

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1875,6 +1875,7 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
 		if (toggled)
 		{
 			options |= OPT_VIEW;
+            options |= OPT_CACHE;
 		}
 		else
 		{
@@ -1890,6 +1891,8 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
         else
         {
             options ^= OPT_CACHE;
+            if (options & OPT_VIEW)
+                options ^= OPT_VIEW;
         }
     }
 
@@ -1898,7 +1901,10 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
     info.newValue = options;
     info.oldValue = oldOpts;
 
-    if (m_subGpIndex.data(ROLE_OBJNAME).toString() == "main") {
+    std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
+    ZASSERT_EXIT(mgr);
+    bool toggleCachedNodeViewBtn = btn == STATUS_VIEW && mgr->nodeCacheExist(m_index.data(ROLE_OBJID).toString());  //toggle viewBtn and it has been cached
+    if (!toggleCachedNodeViewBtn && m_subGpIndex.data(ROLE_OBJNAME).toString() == "main") {
         pGraphsModel->markNodeDataChanged(m_index);
         onMarkDataChanged(true);
     }

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1898,12 +1898,12 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
     info.newValue = options;
     info.oldValue = oldOpts;
 
-    pGraphsModel->updateNodeStatus(nodeId(), info, m_subGpIndex, true);
-
     if (m_subGpIndex.data(ROLE_OBJNAME).toString() == "main") {
         pGraphsModel->markNodeDataChanged(m_index);
         onMarkDataChanged(true);
     }
+
+    pGraphsModel->updateNodeStatus(nodeId(), info, m_subGpIndex, true);
 }
 
 void ZenoNode::onCollaspeUpdated(bool collasped)

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1431,9 +1431,11 @@ void ZenoNode::onMarkDataChanged(bool bDirty)
     {
         clrMarker = QColor(0, 0, 0, 0);
     }
-    ZASSERT_EXIT(m_dirtyMarker);
-    m_dirtyMarker->setColors(false, clrMarker);
-    updateWhole();
+    if (m_dirtyMarker)
+    {
+        m_dirtyMarker->setColors(false, clrMarker);
+        updateWhole();
+    }
 }
 
 void ZenoNode::setMoving(bool isMoving)

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1899,6 +1899,11 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
     info.oldValue = oldOpts;
 
     pGraphsModel->updateNodeStatus(nodeId(), info, m_subGpIndex, true);
+
+    if (m_subGpIndex.data(ROLE_OBJNAME).toString() == "main") {
+        pGraphsModel->markNodeDataChanged(m_index);
+        onMarkDataChanged(true);
+    }
 }
 
 void ZenoNode::onCollaspeUpdated(bool collasped)

--- a/ui/zenoedit/nodesys/zenosubgraphscene.cpp
+++ b/ui/zenoedit/nodesys/zenosubgraphscene.cpp
@@ -88,6 +88,10 @@ void ZenoSubGraphScene::initModel(const QModelIndex& index)
         {
             blackboardVect << pNode;
         }
+        if (m_subgIdx.data(ROLE_OBJNAME).toString() == "main") {
+            pGraphsModel->markNodeDataChanged(idx, false);
+            pNode->onMarkDataChanged(true);
+        }
     }
 
     for (auto it : m_nodes)
@@ -1063,6 +1067,10 @@ void ZenoSubGraphScene::onRowsInserted(const QModelIndex& subgIdx, const QModelI
                     pGroup->appendChildItem(pChildNode);
             }
         }
+    }
+    if (m_subgIdx.data(ROLE_OBJNAME).toString() == "main") {  //new nodes mark dirty
+        pGraphsModel->markNodeDataChanged(idx, false);
+        pNode->onMarkDataChanged(true);
     }
 }
 

--- a/ui/zenoedit/nodesys/zenosubgraphscene.cpp
+++ b/ui/zenoedit/nodesys/zenosubgraphscene.cpp
@@ -30,11 +30,13 @@
 #include "viewport/viewportwidget.h"
 #include "viewport/displaywidget.h"
 #include "zenomainwindow.h"
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <viewportinteraction/picker.h>
 #include "settings/zenosettingsmanager.h"
 #include "timeline/ztimeline.h"
 #include <zenoui/comctrl/gv/zgraphicsnetlabel.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 ZenoSubGraphScene::ZenoSubGraphScene(QObject *parent)
     : QGraphicsScene(parent)
@@ -1094,7 +1096,7 @@ void ZenoSubGraphScene::selectObjViaNodes() {
         for (auto item : selItems) {
             if (auto *pNode = qgraphicsitem_cast<ZenoNode *>(item)) {
                 auto node_id = pNode->index().data(ROLE_OBJID).toString().toStdString();
-                for (const auto &[prim_name, _] : scene->objectsMan->pairsShared()) {
+                for (const auto &[prim_name, _] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
                     if (prim_name.find(node_id) != std::string::npos)
                         picker->add(prim_name);
                 }

--- a/ui/zenoedit/nodesys/zenosubgraphscene.cpp
+++ b/ui/zenoedit/nodesys/zenosubgraphscene.cpp
@@ -1096,10 +1096,9 @@ void ZenoSubGraphScene::selectObjViaNodes() {
         for (auto item : selItems) {
             if (auto *pNode = qgraphicsitem_cast<ZenoNode *>(item)) {
                 auto node_id = pNode->index().data(ROLE_OBJID).toString().toStdString();
-                for (const auto &[prim_name, _] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
-                    if (prim_name.find(node_id) != std::string::npos)
-                        picker->add(prim_name);
-                }
+                auto key = zeno::getSession().globalComm->getObjKeyByObjID(node_id);
+                if (key != "")
+                    picker->add(key);
             }
         }
         picker->sync_to_scene();

--- a/ui/zenoedit/panel/ZLightsModel.cpp
+++ b/ui/zenoedit/panel/ZLightsModel.cpp
@@ -54,11 +54,7 @@ void ZLightsModel::updateByObjectsMan() {
     auto scene = session->get_scene();
     ZERROR_EXIT(scene);
 
-    for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->lightObjects) {
-        if (ptr->userData().get2<int>("isL", 0)) {
-            light_names.push_back(key);
-        }
-    }
+    zeno::getSession().globalComm->getAllLightsKey(light_names);
 
     endResetModel();
 }

--- a/ui/zenoedit/panel/ZLightsModel.cpp
+++ b/ui/zenoedit/panel/ZLightsModel.cpp
@@ -6,13 +6,15 @@
 #include "viewport/zenovis.h"
 #include "zeno/utils/log.h"
 #include <zeno/types/UserData.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/types/PrimitiveObject.h>
 #include "zassert.h"
 #include "zenoapplication.h"
 #include "zenomainwindow.h"
 #include "viewport/viewportwidget.h"
 #include "viewport/displaywidget.h"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 int ZLightsModel::rowCount(const QModelIndex &parent) const {
@@ -52,7 +54,7 @@ void ZLightsModel::updateByObjectsMan() {
     auto scene = session->get_scene();
     ZERROR_EXIT(scene);
 
-    for (auto const &[key, ptr]: scene->objectsMan->lightObjects) {
+    for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->lightObjects) {
         if (ptr->userData().get2<int>("isL", 0)) {
             light_names.push_back(key);
         }

--- a/ui/zenoedit/panel/zenoimagepanel.cpp
+++ b/ui/zenoedit/panel/zenoimagepanel.cpp
@@ -5,7 +5,7 @@
 #include "zenoimagepanel.h"
 #include "PrimAttrTableModel.h"
 #include "viewport/zenovis.h"
-#include "zenovis/ObjectsManager.h"
+#include "zeno/extra/ObjectsManager.h"
 #include "zeno/utils/format.h"
 #include <zeno/types/UserData.h>
 #include <zeno/types/PrimitiveObject.h>
@@ -16,6 +16,8 @@
 #include "viewport/viewportwidget.h"
 #include "zenomainwindow.h"
 #include "viewport/displaywidget.h"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 void ZenoImagePanel::clear() {
@@ -44,7 +46,7 @@ void ZenoImagePanel::setPrim(std::string primid) {
 
     bool enableGamma = pGamma->checkState() == Qt::Checked;
     bool found = false;
-    for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+    for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
         if ((key.substr(0, key.find(":"))) != primid) {
             continue;
         }
@@ -176,7 +178,7 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
             if (key.find(prim_name) == 0 && key.find(zeno::format(":{}:", frame)) != std::string::npos) {
                 setPrim(key);
             }
@@ -190,7 +192,7 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
             if (key.find(prim_name) == 0) {
                 setPrim(key);
             }
@@ -204,7 +206,7 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
             if (key.find(prim_name) == 0) {
                 setPrim(key);
             }
@@ -230,7 +232,7 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         if (!scene)
             return;
         bool found = false;
-        for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
             if ((key.substr(0, key.find(":"))) != primid) {
                 continue;
             }

--- a/ui/zenoedit/panel/zenoimagepanel.cpp
+++ b/ui/zenoedit/panel/zenoimagepanel.cpp
@@ -46,64 +46,67 @@ void ZenoImagePanel::setPrim(std::string primid) {
 
     bool enableGamma = pGamma->checkState() == Qt::Checked;
     bool found = false;
-    for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
-        if ((key.substr(0, key.find(":"))) != primid) {
-            continue;
-        }
-        auto &ud = ptr->userData();
-        if (ud.get2<int>("isImage", 0) == 0) {
-            continue;
-        }
-        found = true;
-        if (auto obj = dynamic_cast<zeno::PrimitiveObject *>(ptr)) {
-            int width = ud.get2<int>("w");
-            int height = ud.get2<int>("h");
-            if (image_view) {
-                if (pMode->currentText() != "Alpha") {
-                    QImage img(width, height, QImage::Format_RGB32);
-                    auto index = std::map<QString, zeno::vec3i>{
-                        {"RGB", {0, 1, 2}},
-                        {"Red", {0, 0, 0}},
-                        {"Green", {1, 1, 1}},
-                        {"Blue", {2, 2, 2}},
-                    }.at(pMode->currentText());
-                    for (auto i = 0; i < obj->verts.size(); i++) {
-                        int h = i / width;
-                        int w = i % width;
-                        auto c = obj->verts[i];
-                        if (enableGamma) {
-                            c = zeno::pow(c, 1.0f / 2.2f);
-                        }
-                        int r = glm::clamp(int(c[index[0]] * 255.99), 0, 255);
-                        int g = glm::clamp(int(c[index[1]] * 255.99), 0, 255);
-                        int b = glm::clamp(int(c[index[2]] * 255.99), 0, 255);
-
-                        img.setPixel(w, height - 1 - h, qRgb(r, g, b));
-                    }
-                    image_view->setImage(img);
-                }
-                else if (pMode->currentText() == "Alpha") {
-                    QImage img(width, height, QImage::Format_RGB32);
-                    if (obj->verts.has_attr("alpha")) {
-                        auto &alpha = obj->verts.attr<float>("alpha");
+    const auto& cb = [&]() {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->pairs()) {
+            if ((key.substr(0, key.find(":"))) != primid) {
+                continue;
+            }
+            auto &ud = ptr->userData();
+            if (ud.get2<int>("isImage", 0) == 0) {
+                continue;
+            }
+            found = true;
+            if (auto obj = dynamic_cast<zeno::PrimitiveObject *>(ptr)) {
+                int width = ud.get2<int>("w");
+                int height = ud.get2<int>("h");
+                if (image_view) {
+                    if (pMode->currentText() != "Alpha") {
+                        QImage img(width, height, QImage::Format_RGB32);
+                        auto index = std::map<QString, zeno::vec3i>{
+                            {"RGB", {0, 1, 2}},
+                            {"Red", {0, 0, 0}},
+                            {"Green", {1, 1, 1}},
+                            {"Blue", {2, 2, 2}},
+                        }.at(pMode->currentText());
                         for (auto i = 0; i < obj->verts.size(); i++) {
                             int h = i / width;
                             int w = i % width;
-                            auto c = alpha[i];
-                            int r = glm::clamp(int(c * 255.99), 0, 255);
-                            int g = glm::clamp(int(c * 255.99), 0, 255);
-                            int b = glm::clamp(int(c * 255.99), 0, 255);
+                            auto c = obj->verts[i];
+                            if (enableGamma) {
+                                c = zeno::pow(c, 1.0f / 2.2f);
+                            }
+                            int r = glm::clamp(int(c[index[0]] * 255.99), 0, 255);
+                            int g = glm::clamp(int(c[index[1]] * 255.99), 0, 255);
+                            int b = glm::clamp(int(c[index[2]] * 255.99), 0, 255);
 
                             img.setPixel(w, height - 1 - h, qRgb(r, g, b));
                         }
+                        image_view->setImage(img);
                     }
-                    image_view->setImage(img);
+                    else if (pMode->currentText() == "Alpha") {
+                        QImage img(width, height, QImage::Format_RGB32);
+                        if (obj->verts.has_attr("alpha")) {
+                            auto &alpha = obj->verts.attr<float>("alpha");
+                            for (auto i = 0; i < obj->verts.size(); i++) {
+                                int h = i / width;
+                                int w = i % width;
+                                auto c = alpha[i];
+                                int r = glm::clamp(int(c * 255.99), 0, 255);
+                                int g = glm::clamp(int(c * 255.99), 0, 255);
+                                int b = glm::clamp(int(c * 255.99), 0, 255);
+
+                                img.setPixel(w, height - 1 - h, qRgb(r, g, b));
+                            }
+                        }
+                        image_view->setImage(img);
+                    }
                 }
+                QString statusInfo = QString(zeno::format("width: {}, height: {}", width, height).c_str());
+                pStatusBar->setText(statusInfo);
             }
-            QString statusInfo = QString(zeno::format("width: {}, height: {}", width, height).c_str());
-            pStatusBar->setText(statusInfo);
         }
-    }
+    };
+    zeno::getSession().globalComm->mutexCallback(cb);
     if (found == false) {
         clear();
     }
@@ -178,11 +181,9 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
-            if (key.find(prim_name) == 0 && key.find(zeno::format(":{}:", frame)) != std::string::npos) {
+        std::string key = zeno::getSession().globalComm->getObjKey1(prim_name, frame);
+        if (key != "")
                 setPrim(key);
-            }
-        }
     });
     connect(pGamma, &QCheckBox::stateChanged, this, [=](int state) {
         std::string prim_name = pPrimName->text().toStdString();
@@ -192,11 +193,10 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
-            if (key.find(prim_name) == 0) {
-                setPrim(key);
-            }
-        }
+
+        auto key = zeno::getSession().globalComm->getObjKeyByObjID(prim_name);
+        if (key != "")
+            setPrim(key);
     });
     connect(pMode, &ZComboBox::_textActivated, [=](const QString& text) {
         std::string prim_name = pPrimName->text().toStdString();
@@ -206,11 +206,9 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
-            if (key.find(prim_name) == 0) {
-                setPrim(key);
-            }
-        }
+        auto key = zeno::getSession().globalComm->getObjKeyByObjID(prim_name);
+        if (key != "")
+            setPrim(key);
     });
 
     connect(pFit, &QPushButton::clicked, this, [=](bool _) {
@@ -232,47 +230,50 @@ ZenoImagePanel::ZenoImagePanel(QWidget *parent) : QWidget(parent) {
         if (!scene)
             return;
         bool found = false;
-        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
-            if ((key.substr(0, key.find(":"))) != primid) {
-                continue;
-            }
-            auto &ud = ptr->userData();
-            if (ud.get2<int>("isImage", 0) == 0) {
-                continue;
-            }
-            found = true;
-            if (auto obj = dynamic_cast<zeno::PrimitiveObject *>(ptr)) {
-                int width = ud.get2<int>("w");
-                int height = ud.get2<int>("h");
-                int w = int(zeno::clamp(x, 0, width - 1));
-                int h = int(zeno::clamp(y, 0, height - 1));
-                int i = (height - 1 - h) * width + w;
-                auto c = obj->verts[i];
-                std::string info = zeno::format("width: {}, height: {}", width, height);
-                info += zeno::format(" | x: {:5}, y: {:5}", w, h);
-                if (obj->verts.has_attr("alpha")) {
-                    auto &alpha = obj->verts.attr<float>("alpha");
-                    info += zeno::format(
-                        " | value: {}, {}, {}, {}",
-                        QString::number(c[0], 'f', 6).toStdString(),
-                        QString::number(c[1], 'f', 6).toStdString(),
-                        QString::number(c[2], 'f', 6).toStdString(),
-                        QString::number(alpha[i], 'f', 6).toStdString()
-                    );
+        const auto& cb = [&]() {
+            for (auto const& [key, ptr] : zeno::getSession().globalComm->pairs()) {
+                if ((key.substr(0, key.find(":"))) != primid) {
+                    continue;
                 }
-                else {
-                    info += zeno::format(
-                        " | value: {}, {}, {}",
-                        QString::number(c[0], 'f', 6).toStdString(),
-                        QString::number(c[1], 'f', 6).toStdString(),
-                        QString::number(c[2], 'f', 6).toStdString()
-                    );
+                auto& ud = ptr->userData();
+                if (ud.get2<int>("isImage", 0) == 0) {
+                    continue;
                 }
+                found = true;
+                if (auto obj = dynamic_cast<zeno::PrimitiveObject*>(ptr)) {
+                    int width = ud.get2<int>("w");
+                    int height = ud.get2<int>("h");
+                    int w = int(zeno::clamp(x, 0, width - 1));
+                    int h = int(zeno::clamp(y, 0, height - 1));
+                    int i = (height - 1 - h) * width + w;
+                    auto c = obj->verts[i];
+                    std::string info = zeno::format("width: {}, height: {}", width, height);
+                    info += zeno::format(" | x: {:5}, y: {:5}", w, h);
+                    if (obj->verts.has_attr("alpha")) {
+                        auto& alpha = obj->verts.attr<float>("alpha");
+                        info += zeno::format(
+                            " | value: {}, {}, {}, {}",
+                            QString::number(c[0], 'f', 6).toStdString(),
+                            QString::number(c[1], 'f', 6).toStdString(),
+                            QString::number(c[2], 'f', 6).toStdString(),
+                            QString::number(alpha[i], 'f', 6).toStdString()
+                        );
+                    }
+                    else {
+                        info += zeno::format(
+                            " | value: {}, {}, {}",
+                            QString::number(c[0], 'f', 6).toStdString(),
+                            QString::number(c[1], 'f', 6).toStdString(),
+                            QString::number(c[2], 'f', 6).toStdString()
+                        );
+                    }
 
-                QString statusInfo = QString(info.c_str());
-                pStatusBar->setText(statusInfo);
+                    QString statusInfo = QString(info.c_str());
+                    pStatusBar->setText(statusInfo);
+                }
             }
-        }
+        };
+        zeno::getSession().globalComm->mutexCallback(cb);
         if (found == false) {
             clear();
         }

--- a/ui/zenoedit/panel/zenolights.cpp
+++ b/ui/zenoedit/panel/zenolights.cpp
@@ -10,9 +10,11 @@
 #include "zeno/core/Session.h"
 #include <zeno/types/PrimitiveObject.h>
 #include <zenoui/comctrl/zcombobox.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/types/UserData.h>
 #include <glm/glm.hpp>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 ZenoLights::ZenoLights(QWidget *parent) : QWidget(parent) {
@@ -144,7 +146,7 @@ ZenoLights::ZenoLights(QWidget *parent) : QWidget(parent) {
         ZASSERT_EXIT(scene);
 
         //todo: move objsMan outof scene.
-        for (auto const &[key, ptr]: scene->objectsMan->lightObjects) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->lightObjects) {
             if (key.find("LightNode") != std::string::npos) {
                 QString primid = QString(key.c_str());
                 write_param_into_node(primid);
@@ -162,7 +164,7 @@ ZenoLights::ZenoLights(QWidget *parent) : QWidget(parent) {
         auto scene = pZenovis->getSession()->get_scene();
         ZASSERT_EXIT(scene);
 
-        for (auto const &[key, ptr]: scene->objectsMan->lightObjects) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->lightObjects) {
             if (key.find("ProceduralSky") != std::string::npos) {
                 QString primid = QString(key.c_str());
                 write_param_into_node(primid);
@@ -202,7 +204,7 @@ ZenoLights::ZenoLights(QWidget *parent) : QWidget(parent) {
         auto scene = pZenovis->getSession()->get_scene();
         ZASSERT_EXIT(scene);
 
-        std::shared_ptr<zeno::IObject> ptr = scene->objectsMan->lightObjects[name];
+        std::shared_ptr<zeno::IObject> ptr = zeno::getSession().globalComm->objectsMan->lightObjects[name];
 
         if (auto prim_in = dynamic_cast<zeno::PrimitiveObject *>(ptr.get())){
             zeno::vec3f pos = ptr->userData().getLiterial<zeno::vec3f>("pos", zeno::vec3f(0.0f));
@@ -572,7 +574,7 @@ void ZenoLights::modifyLightData() {
         auto scene = pZenoVis->getSession()->get_scene();
         ZASSERT_EXIT(scene);
 
-        std::shared_ptr<zeno::IObject> obj = scene->objectsMan->lightObjects[name];
+        std::shared_ptr<zeno::IObject> obj = zeno::getSession().globalComm->objectsMan->lightObjects[name];
         auto prim_in = dynamic_cast<zeno::PrimitiveObject *>(obj.get());
 
         if (prim_in) {
@@ -591,7 +593,7 @@ void ZenoLights::modifyLightData() {
                 prim_in->userData().setLiterial<float>("intensity", std::move(intensity));
             }
 
-            scene->objectsMan->needUpdateLight = true;
+            zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
             pDisplay->setSimpleRenderOption();
             zenoApp->getMainWindow()->updateViewport();
         } else {
@@ -631,7 +633,7 @@ void ZenoLights::modifySunLightDir() {
         auto scene = pZenovis->getSession()->get_scene();
         ZASSERT_EXIT(scene);
 
-        for (auto const &[key, obj] : scene->objectsMan->lightObjects) {
+        for (auto const &[key, obj] : zeno::getSession().globalComm->objectsMan->lightObjects) {
             if (key.find("ProceduralSky") != std::string::npos) {
                 found = true;
                 if (auto prim_in = dynamic_cast<zeno::PrimitiveObject *>(obj.get())) {
@@ -667,7 +669,7 @@ void ZenoLights::modifySunLightDir() {
             ud.set2("colorTemperatureMix", std::move(colorTemperatureMixValue));
             ud.set2("colorTemperature", std::move(colorTemperatureValue));
         }
-        scene->objectsMan->needUpdateLight = true;
+        zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
         pDisplayWid->setSimpleRenderOption();
         zenoApp->getMainWindow()->updateViewport();
     }
@@ -684,10 +686,10 @@ void ZenoLights::write_param_into_node(const QString& primid) {
         ZASSERT_EXIT(pZenovis);
         auto scene = pZenovis->getSession()->get_scene();
 
-        if (scene->objectsMan->lightObjects.find(primid.toStdString()) == scene->objectsMan->lightObjects.end()) {
+        if (zeno::getSession().globalComm->objectsMan->lightObjects.find(primid.toStdString()) == zeno::getSession().globalComm->objectsMan->lightObjects.end()) {
             return;
         }
-        auto realtime_obj = scene->objectsMan->lightObjects[primid.toStdString()];
+        auto realtime_obj = zeno::getSession().globalComm->objectsMan->lightObjects[primid.toStdString()];
         auto ud = realtime_obj->userData();
         IGraphsModel* pIGraphsModel = zenoApp->graphsManagment()->currentModel();
         if (pIGraphsModel == nullptr) {

--- a/ui/zenoedit/panel/zenospreadsheet.cpp
+++ b/ui/zenoedit/panel/zenospreadsheet.cpp
@@ -5,7 +5,7 @@
 #include "zenospreadsheet.h"
 #include "PrimAttrTableModel.h"
 #include "viewport/zenovis.h"
-#include "zenovis/ObjectsManager.h"
+#include "zeno/extra/ObjectsManager.h"
 #include "zeno/utils/format.h"
 #include <zeno/types/UserData.h>
 #include <zeno/types/PrimitiveObject.h>
@@ -13,6 +13,8 @@
 #include "zenomainwindow.h"
 #include "viewport/viewportwidget.h"
 #include "viewport/displaywidget.h"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 ZenoSpreadsheet::ZenoSpreadsheet(QWidget *parent) : QWidget(parent) {
@@ -81,7 +83,7 @@ ZenoSpreadsheet::ZenoSpreadsheet(QWidget *parent) : QWidget(parent) {
         ZERROR_EXIT(sess);
         auto scene = zenovis->getSession()->get_scene();
         ZERROR_EXIT(scene);
-        for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+        for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
             if (key.find(prim_name) == 0 && key.find(zeno::format(":{}:", frame)) != std::string::npos) {
                 setPrim(key);
             }
@@ -136,7 +138,7 @@ void ZenoSpreadsheet::setPrim(std::string primid) {
     ZASSERT_EXIT(scene);
 
     bool found = false;
-    for (auto const &[key, ptr]: scene->objectsMan->pairs()) {
+    for (auto const &[key, ptr]: zeno::getSession().globalComm->objectsMan->pairs()) {
         if (key != primid) {
             continue;
         }

--- a/ui/zenoedit/util/apphelper.cpp
+++ b/ui/zenoedit/util/apphelper.cpp
@@ -391,6 +391,10 @@ void AppHelper::initLaunchCacheParam(LAUNCH_PARAM& param)
     param.cacheDir = settings.value("zencachedir").isValid() ? settings.value("zencachedir").toString() : "";
     param.cacheNum = settings.value("zencachenum").isValid() ? settings.value("zencachenum").toInt() : 1;
     param.autoCleanCacheInCacheRoot = settings.value("zencache-autoclean").isValid() ? settings.value("zencache-autoclean").toBool() : true;
+
+    std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
+    ZASSERT_EXIT(mgr);
+    param.runDirtyNodesOnly = mgr->nextRunSkipCreateDir(param.tempDir);
 }
 
 bool AppHelper::openZsgAndRun(const ZENO_RECORD_RUN_INITPARAM& param, LAUNCH_PARAM launchParam)

--- a/ui/zenoedit/util/apphelper.cpp
+++ b/ui/zenoedit/util/apphelper.cpp
@@ -129,19 +129,19 @@ void AppHelper::modifyOptixObjDirectly(QVariant newValue, QPersistentModelIndex 
     ZenoMainWindow* main = zenoApp->getMainWindow();
     if (nodeIdx.data(ROLE_OBJNAME).toString() == "LightNode" &&
         nodeIdx.data(ROLE_OPTIONS).toInt() == OPT_VIEW &&
-        (main->isAlways() || main->isAlwaysLightCamera() || editByPropPanel))
+        (main->isAlways() || editByPropPanel))
     {
         modifyLightData(newValue, nodeIdx, paramIdx);
     }
     else if ((nodeIdx.data(ROLE_OBJNAME).toString() == "CameraNode" ||
         nodeIdx.data(ROLE_OBJNAME).toString() == "MakeCamera" ||
         nodeIdx.data(ROLE_OBJNAME).toString() == "TargetCamera") &&
-        ((nodeIdx.data(ROLE_OPTIONS).toInt() == OPT_VIEW && (main->isAlways() || main->isAlwaysLightCamera())) || editByPropPanel)
+        (nodeIdx.data(ROLE_OPTIONS).toInt() == OPT_VIEW && (main->isAlways() || editByPropPanel))
         )
     {
         modifyOptixCameraPropDirectly(newValue, nodeIdx, paramIdx);
     }
-    else if (( (main->isAlways() || main->isAlwaysLightCamera() || main->isAlwaysMaterial()) || editByPropPanel))
+    else if (main->isAlways() || editByPropPanel)
     {
         socketEditFinished(newValue, nodeIdx, paramIdx);
     }

--- a/ui/zenoedit/util/apphelper.cpp
+++ b/ui/zenoedit/util/apphelper.cpp
@@ -394,7 +394,8 @@ void AppHelper::initLaunchCacheParam(LAUNCH_PARAM& param)
 
     std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
     ZASSERT_EXIT(mgr);
-    param.runDirtyNodesOnly = mgr->nextRunSkipCreateDir(param);
+    if (!mgr->nextRunSkipCreateDir(param))
+        markAllNodesInMainGraphDirty(false);
 }
 
 bool AppHelper::openZsgAndRun(const ZENO_RECORD_RUN_INITPARAM& param, LAUNCH_PARAM launchParam)
@@ -497,5 +498,20 @@ void AppHelper::dumpTabsToZsg(QDockWidget* dockWidget, RAPIDJSON_WRITER& writer)
                 writer.String("Light");
             }
         }
+    }
+}
+
+void AppHelper::markAllNodesInMainGraphDirty(bool markNodeStyle)
+{
+    IGraphsModel* pModel = zenoApp->graphsManagment()->currentModel();
+    if (!pModel)
+        return;
+    QModelIndex subgIdx = pModel->index("main");
+    for (int i = 0; i < pModel->itemCount(subgIdx); i++)
+    {
+        const QModelIndex& idx = pModel->index(i, subgIdx);
+        pModel->markNodeDataChanged(idx, false);
+        if (markNodeStyle)  //change node style in subgraphScene
+            emit pModel->_dataChanged(subgIdx, idx, ROLE_NODE_DATACHANGED);
     }
 }

--- a/ui/zenoedit/util/apphelper.cpp
+++ b/ui/zenoedit/util/apphelper.cpp
@@ -394,7 +394,7 @@ void AppHelper::initLaunchCacheParam(LAUNCH_PARAM& param)
 
     std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
     ZASSERT_EXIT(mgr);
-    param.runDirtyNodesOnly = mgr->nextRunSkipCreateDir(param.tempDir);
+    param.runDirtyNodesOnly = mgr->nextRunSkipCreateDir(param);
 }
 
 bool AppHelper::openZsgAndRun(const ZENO_RECORD_RUN_INITPARAM& param, LAUNCH_PARAM launchParam)

--- a/ui/zenoedit/util/apphelper.h
+++ b/ui/zenoedit/util/apphelper.h
@@ -34,6 +34,7 @@ public:
     static bool getCurveValue(QVariant & val);
     static bool updateCurve(QVariant oldVal, QVariant& val);
     static void dumpTabsToZsg(QDockWidget* dockWidget, RAPIDJSON_WRITER& writer);
+    static void markAllNodesInMainGraphDirty(bool markNodeStyle = true);
 };
 
 

--- a/ui/zenoedit/util/apphelper.h
+++ b/ui/zenoedit/util/apphelper.h
@@ -6,7 +6,7 @@
 #include <zenomodel/include/graphsmanagment.h>
 #include <zenomodel/include/igraphsmodel.h>
 #include "zenomainwindow.h"
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/types/UserData.h>
 #include <zenoui/comctrl/gv/zveceditoritem.h>
 #include <viewport/viewportwidget.h>

--- a/ui/zenoedit/viewport/cameracontrol.cpp
+++ b/ui/zenoedit/viewport/cameracontrol.cpp
@@ -235,11 +235,11 @@ void CameraControl::changeTransformOperation(const QString &node)
     ZASSERT_EXIT(m_zenovis);
 
     auto scene = m_zenovis->getSession()->get_scene();
-    for (auto const &[key, _] : zeno::getSession().globalComm->objectsMan->pairs()) {
-        if (key.find(node.toStdString()) != std::string::npos) {
+    auto key = zeno::getSession().globalComm->getObjKeyByObjID(node.toStdString());
+    if (key != "")
+    {
             scene->selected.insert(key);
             m_transformer->addObject(key);
-        }
     }
     m_transformer->setTransOpt(opt);
     m_transformer->changeTransOpt();
@@ -411,13 +411,9 @@ void CameraControl::fakeMouseDoubleClickEvent(QMouseEvent *event)
     auto scene = m_zenovis->getSession()->get_scene();
     auto picked_prim = m_picker->just_pick_prim(pos.x(), pos.y());
     if (!picked_prim.empty()) {
-        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
-        for (auto const &[key, ptr]: primList) {
-            if (picked_prim == key) {
-                auto &ud = ptr->userData();
-                std::cout<<"selected MatId: "<<ud.get2<std::string>("mtlid", "Default")<<"\n";
-            }
-        }
+        auto key = zeno::getSession().globalComm->getObjMatId(picked_prim);
+        if (key != "")
+            std::cout << "selected MatId: " << key << "\n";
         auto obj_node_location = zeno::NodeSyncMgr::GetInstance().searchNodeOfPrim(picked_prim);
         auto subgraph_name = obj_node_location->subgraph.data(ROLE_OBJNAME).toString();
         auto obj_node_name = obj_node_location->node.data(ROLE_OBJID).toString();
@@ -582,13 +578,9 @@ void CameraControl::fakeMouseReleaseEvent(QMouseEvent *event) {
                 for(auto prim:m_picker->get_picked_prims())
                 {
                     if (!prim.empty()) {
-                        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
-                        for (auto const &[key, ptr]: primList) {
-                            if (prim == key) {
-                                auto &ud = ptr->userData();
-                                std::cout<<"selected MatId: "<<ud.get2<std::string>("mtlid", "Default")<<"\n";
-                            }
-                        }
+                        auto key = zeno::getSession().globalComm->getObjMatId(prim);
+                        if (key != "")
+                            std::cout << "selected MatId: " << key << "\n";
                     }
                 }
             } else {
@@ -619,13 +611,9 @@ void CameraControl::fakeMouseReleaseEvent(QMouseEvent *event) {
                 for(auto prim:m_picker->get_picked_prims())
                 {
                     if (!prim.empty()) {
-                        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
-                        for (auto const &[key, ptr]: primList) {
-                            if (prim == key) {
-                                auto &ud = ptr->userData();
-                                std::cout<<"selected MatId: "<<ud.get2<std::string>("mtlid", "Default")<<"\n";
-                            }
-                        }
+                        auto key = zeno::getSession().globalComm->getObjMatId(prim);
+                        if (key != "")
+                            std::cout << "selected MatId: " << key << "\n";
                         auto obj_node_location = zeno::NodeSyncMgr::GetInstance().searchNodeOfPrim(prim);
                         if (!obj_node_location)
                         {

--- a/ui/zenoedit/viewport/cameracontrol.cpp
+++ b/ui/zenoedit/viewport/cameracontrol.cpp
@@ -2,11 +2,13 @@
 #include "cameracontrol.h"
 #include "zenovis.h"
 //#include <zenovis/Camera.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include "zenomainwindow.h"
 #include "nodesview/zenographseditor.h"
 #include <zeno/types/UserData.h>
 #include "settings/zenosettingsmanager.h"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 
 using std::string;
@@ -233,7 +235,7 @@ void CameraControl::changeTransformOperation(const QString &node)
     ZASSERT_EXIT(m_zenovis);
 
     auto scene = m_zenovis->getSession()->get_scene();
-    for (auto const &[key, _] : scene->objectsMan->pairs()) {
+    for (auto const &[key, _] : zeno::getSession().globalComm->objectsMan->pairs()) {
         if (key.find(node.toStdString()) != std::string::npos) {
             scene->selected.insert(key);
             m_transformer->addObject(key);
@@ -409,7 +411,7 @@ void CameraControl::fakeMouseDoubleClickEvent(QMouseEvent *event)
     auto scene = m_zenovis->getSession()->get_scene();
     auto picked_prim = m_picker->just_pick_prim(pos.x(), pos.y());
     if (!picked_prim.empty()) {
-        auto primList = scene->objectsMan->pairs();
+        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
         for (auto const &[key, ptr]: primList) {
             if (picked_prim == key) {
                 auto &ud = ptr->userData();
@@ -580,7 +582,7 @@ void CameraControl::fakeMouseReleaseEvent(QMouseEvent *event) {
                 for(auto prim:m_picker->get_picked_prims())
                 {
                     if (!prim.empty()) {
-                        auto primList = scene->objectsMan->pairs();
+                        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
                         for (auto const &[key, ptr]: primList) {
                             if (prim == key) {
                                 auto &ud = ptr->userData();
@@ -617,7 +619,7 @@ void CameraControl::fakeMouseReleaseEvent(QMouseEvent *event) {
                 for(auto prim:m_picker->get_picked_prims())
                 {
                     if (!prim.empty()) {
-                        auto primList = scene->objectsMan->pairs();
+                        auto primList = zeno::getSession().globalComm->objectsMan->pairs();
                         for (auto const &[key, ptr]: primList) {
                             if (prim == key) {
                                 auto &ud = ptr->userData();

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -533,26 +533,17 @@ void DisplayWidget::onSliderValueChanged(int frame)
     for (auto displayWid : mainWin->viewports())
         if (!displayWid->isGLViewport())
             displayWid->setRenderSeparately(false, false);
-    if (mainWin->isAlways() || mainWin->isAlwaysLightCamera() || mainWin->isAlwaysMaterial())
+    if (mainWin->isAlways())
     {
         auto pGraphsMgr = zenoApp->graphsManagment();
         IGraphsModel *pModel = pGraphsMgr->currentModel();
         if (!pModel)
             return;
-        std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
-        ZASSERT_EXIT(mgr);
-        ZCacheMgr::cacheOption oldCacheOpt = mgr->getCacheOption();
-        zeno::scope_exit sp([=] {mgr->setCacheOpt(oldCacheOpt); });     //restore old cache option
-        mgr->setCacheOpt(ZCacheMgr::Opt_AlwaysOn);
 
         LAUNCH_PARAM launchParam;
         launchParam.beginFrame = frame;
         launchParam.endFrame = frame;
         launchParam.projectFps = mainWin->timelineInfo().timelinefps;
-        if (mainWin->isAlwaysLightCamera() || mainWin->isAlwaysMaterial()) {
-            launchParam.applyLightAndCameraOnly = mainWin->isAlwaysLightCamera();
-            launchParam.applyMaterialOnly = mainWin->isAlwaysMaterial();
-        }
         AppHelper::initLaunchCacheParam(launchParam);
         launchProgram(pModel, launchParam);
     }
@@ -868,12 +859,6 @@ void DisplayWidget::onRecord()
             ZASSERT_EXIT(main);
             launchParam.projectFps = main->timelineInfo().timelinefps;
             launchParam.zsgPath = zenoApp->graphsManagment()->zsgDir();
-
-            std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
-            ZASSERT_EXIT(mgr);
-            ZCacheMgr::cacheOption oldCacheOpt = mgr->getCacheOption();
-            zeno::scope_exit sp([=] {mgr->setCacheOpt(oldCacheOpt);});  //restore old cache option
-            mgr->setCacheOpt(ZCacheMgr::Opt_RunAll);
 
 #ifdef ZENO_OPTIX_PROC
             if (!m_bGLView)

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -3,7 +3,7 @@
 #include "optixviewport.h"
 #include "zoptixviewport.h"
 #include <zenovis/RenderEngine.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenovis/Camera.h>
 #include <zeno/extra/GlobalComm.h>
 #include <zeno/extra/GlobalState.h>
@@ -482,7 +482,7 @@ void DisplayWidget::onCommandDispatched(int actionType, bool bChecked)
         {
             int frameid = m_glView->getSession()->get_curr_frameid();
             auto *scene = m_glView->getSession()->get_scene();
-            for (auto const &[key, ptr] : scene->objectsMan->pairs()) {
+            for (auto const &[key, ptr] : zeno::getSession().globalComm->objectsMan->pairs()) {
                 if (key.find("MakeCamera") != std::string::npos &&
                     key.find(zeno::format(":{}:", frameid)) != std::string::npos) {
                     auto cam = dynamic_cast<zeno::CameraObject *>(ptr)->get();
@@ -616,7 +616,7 @@ void DisplayWidget::afterRun()
         ZASSERT_EXIT(session);
         auto scene = session->get_scene();
         ZASSERT_EXIT(scene);
-        scene->objectsMan->lightObjects.clear();
+        zeno::getSession().globalComm->objectsMan->lightObjects.clear();
     }
 }
 
@@ -646,7 +646,7 @@ void DisplayWidget::onRun(LAUNCH_PARAM launchParam)
     Zenovis* pZenoVis = getZenoVis();
     ZASSERT_EXIT(pZenoVis);
     auto scene = pZenoVis->getSession()->get_scene();
-    scene->objectsMan->lightObjects.clear();
+    zeno::getSession().globalComm->objectsMan->lightObjects.clear();
     ZTimeline* timeline = mainWin->timeline();
     ZASSERT_EXIT(timeline);
 }
@@ -686,7 +686,7 @@ void DisplayWidget::onRun() {
     Zenovis* pZenoVis = getZenoVis();
     ZASSERT_EXIT(pZenoVis);
     auto scene = pZenoVis->getSession()->get_scene();
-    scene->objectsMan->lightObjects.clear();
+    zeno::getSession().globalComm->objectsMan->lightObjects.clear();
 }
 
 void DisplayWidget::runAndRecord(const VideoRecInfo &recInfo) {
@@ -1180,7 +1180,7 @@ void DisplayWidget::onNodeSelected(const QModelIndex &subgIdx, const QModelIndex
             // find prim in object manager
             auto input_node_id = input_nodes[0].get_node_id();
             string prim_name;
-            for (const auto &[k, v] : scene->objectsMan->pairsShared()) {
+            for (const auto &[k, v] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
                 if (k.find(input_node_id.toStdString()) != string::npos)
                     prim_name = k;
             }

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -851,7 +851,7 @@ void DisplayWidget::onRecord()
             }*/
 
             //clear cached objs.
-            zeno::getSession().globalComm->clearState();
+            //zeno::getSession().globalComm->clearState();
             launchParam.beginFrame = recInfo.frameRange.first;
             launchParam.endFrame = recInfo.frameRange.second;
             launchParam.autoRmCurcache = recInfo.bAutoRemoveCache && launchParam.enableCache;
@@ -859,6 +859,10 @@ void DisplayWidget::onRecord()
             ZASSERT_EXIT(main);
             launchParam.projectFps = main->timelineInfo().timelinefps;
             launchParam.zsgPath = zenoApp->graphsManagment()->zsgDir();
+
+            std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
+            ZASSERT_EXIT(mgr);
+            mgr->setNewCacheDir(true);
 
 #ifdef ZENO_OPTIX_PROC
             if (!m_bGLView)

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -545,6 +545,7 @@ void DisplayWidget::onSliderValueChanged(int frame)
         launchParam.endFrame = frame;
         launchParam.projectFps = mainWin->timelineInfo().timelinefps;
         AppHelper::initLaunchCacheParam(launchParam);
+        launchParam.runDirtyNodesOnly = false;
         launchProgram(pModel, launchParam);
     }
     else
@@ -863,6 +864,7 @@ void DisplayWidget::onRecord()
             std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
             ZASSERT_EXIT(mgr);
             mgr->setNewCacheDir(true);
+            launchParam.runDirtyNodesOnly = false;
 
 #ifdef ZENO_OPTIX_PROC
             if (!m_bGLView)

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -545,7 +545,7 @@ void DisplayWidget::onSliderValueChanged(int frame)
         launchParam.endFrame = frame;
         launchParam.projectFps = mainWin->timelineInfo().timelinefps;
         AppHelper::initLaunchCacheParam(launchParam);
-        launchParam.runDirtyNodesOnly = false;
+        AppHelper::markAllNodesInMainGraphDirty(false);
         launchProgram(pModel, launchParam);
     }
     else
@@ -864,7 +864,7 @@ void DisplayWidget::onRecord()
             std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
             ZASSERT_EXIT(mgr);
             mgr->setNewCacheDir(true);
-            launchParam.runDirtyNodesOnly = false;
+            AppHelper::markAllNodesInMainGraphDirty(false);
 
 #ifdef ZENO_OPTIX_PROC
             if (!m_bGLView)

--- a/ui/zenoedit/viewport/optixviewport.cpp
+++ b/ui/zenoedit/viewport/optixviewport.cpp
@@ -366,6 +366,7 @@ ZOptixViewport::ZOptixViewport(QWidget* parent)
 
     const char *e = "optx";
     m_zenovis->getSession()->set_render_engine(e);
+    zeno::getSession().globalComm->setRenderType(zeno::GlobalComm::NORMAL);
 
     auto scene = m_zenovis->getSession()->get_scene();
 

--- a/ui/zenoedit/viewport/optixviewport.cpp
+++ b/ui/zenoedit/viewport/optixviewport.cpp
@@ -89,49 +89,48 @@ void OptixWorker::onModifyLightData(UI_VECTYPE posvec, UI_VECTYPE scalevec, UI_V
     auto scene = m_zenoVis->getSession()->get_scene();
     ZASSERT_EXIT(scene);
 
-    std::shared_ptr<zeno::IObject> obj;
-    for (auto const& [key, ptr] : zeno::getSession().globalComm->objectsMan->lightObjects) {
-        if (key.find(name) != std::string::npos) {
-            obj = ptr;
-            name = key;
+    const auto& cb = [&]() {
+        for (auto const& [key, ptr] : zeno::getSession().globalComm->getLightObjs()) {
+            if (key.find(name) != std::string::npos) {
+                name = key;
+                if (auto prim_in = dynamic_cast<zeno::PrimitiveObject*>(ptr.get()))
+                {
+                    auto& prim_verts = prim_in->verts;
+                    prim_verts[0] = verts[0];
+                    prim_verts[1] = verts[1];
+                    prim_verts[2] = verts[2];
+                    prim_verts[3] = verts[3];
+
+                    if (skipParam[0])
+                        pos = prim_in->userData().get2<zeno::vec3f>("pos");
+                    if (skipParam[1])
+                        scale = prim_in->userData().get2<zeno::vec3f>("scale");
+                    if (skipParam[2])
+                        rotate = prim_in->userData().get2<zeno::vec3f>("rotate");
+                    if (skipParam[3])
+                        color = prim_in->userData().get2<zeno::vec3f>("color");
+                    if (skipParam[4])
+                        intensity = prim_in->userData().get2<float>("intensity");
+
+                    prim_in->verts.attr<zeno::vec3f>("clr")[0] = color * intensity;
+
+                    prim_in->userData().setLiterial<zeno::vec3f>("pos", std::move(pos));
+                    prim_in->userData().setLiterial<zeno::vec3f>("scale", std::move(scale));
+                    prim_in->userData().setLiterial<zeno::vec3f>("rotate", std::move(rotate));
+                    if (prim_in->userData().has("intensity")) {
+                        prim_in->userData().setLiterial<zeno::vec3f>("color", std::move(color));
+                        prim_in->userData().setLiterial<float>("intensity", std::move(intensity));
+                    }
+                    zeno::getSession().globalComm->setNeedUpdateLight(true);
+                    //pDisplay->setSimpleRenderOption();
+                }
+                else {
+                    zeno::log_info("modifyLightData not found {}", name);
+                }
+            }
         }
-    }
-    auto prim_in = dynamic_cast<zeno::PrimitiveObject*>(obj.get());
-
-    if (prim_in) {
-        auto& prim_verts = prim_in->verts;
-        prim_verts[0] = verts[0];
-        prim_verts[1] = verts[1];
-        prim_verts[2] = verts[2];
-        prim_verts[3] = verts[3];
-
-        if (skipParam[0])
-            pos = prim_in->userData().get2<zeno::vec3f>("pos");
-        if (skipParam[1])
-            scale = prim_in->userData().get2<zeno::vec3f>("scale");
-        if (skipParam[2])
-            rotate = prim_in->userData().get2<zeno::vec3f>("rotate");
-        if (skipParam[3])
-            color = prim_in->userData().get2<zeno::vec3f>("color");
-        if (skipParam[4])
-            intensity = prim_in->userData().get2<float>("intensity");
-
-        prim_in->verts.attr<zeno::vec3f>("clr")[0] = color * intensity;
-
-        prim_in->userData().setLiterial<zeno::vec3f>("pos", std::move(pos));
-        prim_in->userData().setLiterial<zeno::vec3f>("scale", std::move(scale));
-        prim_in->userData().setLiterial<zeno::vec3f>("rotate", std::move(rotate));
-        if (prim_in->userData().has("intensity")) {
-            prim_in->userData().setLiterial<zeno::vec3f>("color", std::move(color));
-            prim_in->userData().setLiterial<float>("intensity", std::move(intensity));
-        }
-
-        zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
-        //pDisplay->setSimpleRenderOption();
-    }
-    else {
-        zeno::log_info("modifyLightData not found {}", name);
-    }
+    };
+    zeno::getSession().globalComm->mutexCallback(cb);
 }
 
 void OptixWorker::onUpdateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam)

--- a/ui/zenoedit/viewport/optixviewport.cpp
+++ b/ui/zenoedit/viewport/optixviewport.cpp
@@ -90,7 +90,7 @@ void OptixWorker::onModifyLightData(UI_VECTYPE posvec, UI_VECTYPE scalevec, UI_V
     ZASSERT_EXIT(scene);
 
     std::shared_ptr<zeno::IObject> obj;
-    for (auto const& [key, ptr] : scene->objectsMan->lightObjects) {
+    for (auto const& [key, ptr] : zeno::getSession().globalComm->objectsMan->lightObjects) {
         if (key.find(name) != std::string::npos) {
             obj = ptr;
             name = key;
@@ -126,7 +126,7 @@ void OptixWorker::onModifyLightData(UI_VECTYPE posvec, UI_VECTYPE scalevec, UI_V
             prim_in->userData().setLiterial<float>("intensity", std::move(intensity));
         }
 
-        scene->objectsMan->needUpdateLight = true;
+        zeno::getSession().globalComm->objectsMan->needUpdateLight = true;
         //pDisplay->setSimpleRenderOption();
     }
     else {

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -226,7 +226,7 @@ void ViewportWidget::paintGL()
     m_zenovis->paintGL();
     if(updateLightOnce){
         auto scene = m_zenovis->getSession()->get_scene();
-        if(zeno::getSession().globalComm->objectsMan->lightObjects.size() > 0){
+        if(zeno::getSession().globalComm->getLightObjsSize() > 0){
             zenoApp->getMainWindow()->updateLightList();
             updateLightOnce = false;
         }

--- a/ui/zenoedit/viewport/viewportwidget.cpp
+++ b/ui/zenoedit/viewport/viewportwidget.cpp
@@ -9,7 +9,7 @@
 #include "dialog/zrecorddlg.h"
 #include "dialog/zrecprogressdlg.h"
 #include <zeno/utils/log.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenovis/DrawOptions.h>
 #include <zeno/funcs/ObjectGeometryInfo.h>
 #include <util/log.h>
@@ -226,7 +226,7 @@ void ViewportWidget::paintGL()
     m_zenovis->paintGL();
     if(updateLightOnce){
         auto scene = m_zenovis->getSession()->get_scene();
-        if(scene->objectsMan->lightObjects.size() > 0){
+        if(zeno::getSession().globalComm->objectsMan->lightObjects.size() > 0){
             zenoApp->getMainWindow()->updateLightList();
             updateLightOnce = false;
         }

--- a/ui/zenoedit/viewportinteraction/nodesync.cpp
+++ b/ui/zenoedit/viewportinteraction/nodesync.cpp
@@ -144,6 +144,7 @@ void NodeSyncMgr::updateNodeVisibility(NodeLocation& node_location) {
     int old_option = node_location.node.data(ROLE_OPTIONS).toInt();
     int new_option = old_option;
     new_option ^= OPT_VIEW;
+    new_option ^= OPT_CACHE;
     STATUS_UPDATE_INFO status_info = {old_option, new_option, ROLE_OPTIONS};
     graph_model->updateNodeStatus(node_id,
                                   status_info,

--- a/ui/zenoedit/viewportinteraction/picker.cpp
+++ b/ui/zenoedit/viewportinteraction/picker.cpp
@@ -8,7 +8,7 @@
 #include <zenomodel/include/graphsmanagment.h>
 
 #include <zenovis/Scene.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenovis/bate/IGraphic.h>
 #include <zeno/funcs/ObjectGeometryInfo.h>
 

--- a/ui/zenoedit/viewportinteraction/transform.cpp
+++ b/ui/zenoedit/viewportinteraction/transform.cpp
@@ -2,13 +2,15 @@
 
 #include <zeno/funcs/PrimitiveTools.h>
 #include <zeno/types/UserData.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenomodel/include/nodesmgr.h>
 #include <zenomodel/include/uihelper.h>
 #include "zenomainwindow.h"
 #include "viewport/viewportwidget.h"
 #include <glm/gtx/transform.hpp>
 #include <glm/gtx/quaternion.hpp>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 namespace zeno {
 
@@ -52,10 +54,10 @@ void FakeTransformer::addObject(const std::string& name) {
     ZASSERT_EXIT(sess);
     auto scene = sess->get_scene();
     ZASSERT_EXIT(scene);
-    if (!scene->objectsMan->get(name).has_value())
+    if (!zeno::getSession().globalComm->objectsMan->get(name).has_value())
         return;
 
-    auto object = dynamic_cast<PrimitiveObject*>(scene->objectsMan->get(name).value());
+    auto object = dynamic_cast<PrimitiveObject*>(zeno::getSession().globalComm->objectsMan->get(name).value());
     m_objects_center *= m_objects.size();
     auto& user_data = object->userData();
     zeno::vec3f bmin, bmax;

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -651,9 +651,9 @@ void ZenoMainWindow::initTimelineDock()
 
     connect(m_pTimeline, &ZTimeline::playForward, this, [=](bool bPlaying) {
         QVector<DisplayWidget*> views = viewports();
-        for (DisplayWidget* view : views) {
-            view->onPlayClicked(bPlaying);
-        }
+    for (DisplayWidget* view : views) {
+        view->onPlayClicked(bPlaying);
+    }
     });
 
     connect(m_pTimeline, &ZTimeline::sliderValueChanged, this, [=](int frame) {

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -64,8 +64,6 @@ ZenoMainWindow::ZenoMainWindow(QWidget *parent, Qt::WindowFlags flags, PANEL_TYP
     : QMainWindow(parent, flags)
     , m_bInDlgEventloop(false)
     , m_bAlways(false)
-    , m_bAlwaysLightCamera(false)
-    , m_bAlwaysMaterial(false)
     , m_pTimeline(nullptr)
     , m_layoutRoot(nullptr)
     , m_nResizeTimes(0)
@@ -667,43 +665,18 @@ void ZenoMainWindow::initTimelineDock()
 
     auto graphs = zenoApp->graphsManagment();
     connect(graphs, &GraphsManagment::modelDataChanged, this, [=]() {
-        if (!m_bAlways && !m_bAlwaysLightCamera && !m_bAlwaysMaterial)
+        if (!m_bAlways)
             return;
-        std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
-        ZASSERT_EXIT(mgr);
-        mgr->setCacheOpt(ZCacheMgr::Opt_AlwaysOn);
         m_pTimeline->togglePlayButton(false);
         int nFrame = m_pTimeline->value();
         QVector<DisplayWidget *> views = viewports();
-        std::function<void(bool, bool)> setOptixUpdateSeparately = [=](bool updateLightCameraOnly, bool updateMatlOnly) {
-            QVector<DisplayWidget *> views = viewports();
-            for (auto displayWid : views) {
-                if (!displayWid->isGLViewport()) {
-                    displayWid->setRenderSeparately(updateLightCameraOnly, updateMatlOnly);
-                }
-            }
-        };
         for (DisplayWidget *view : views) {
-            if (m_bAlways) {
-                setOptixUpdateSeparately(false, false);
-                LAUNCH_PARAM launchParam;
-                launchParam.beginFrame = nFrame;
-                launchParam.endFrame = nFrame;
-                launchParam.projectFps = timeline()->fps();
-                AppHelper::initLaunchCacheParam(launchParam);
-                view->onRun(launchParam);
-            }
-            else if (m_bAlwaysLightCamera || m_bAlwaysMaterial) {
-                setOptixUpdateSeparately(m_bAlwaysLightCamera, m_bAlwaysMaterial);
-                LAUNCH_PARAM launchParam;
-                launchParam.beginFrame = nFrame;
-                launchParam.endFrame = nFrame;
-                launchParam.applyLightAndCameraOnly = m_bAlwaysLightCamera;
-                launchParam.applyMaterialOnly = m_bAlwaysMaterial;
-                launchParam.projectFps = timeline()->fps();
-                AppHelper::initLaunchCacheParam(launchParam);
-                view->onRun(launchParam);
-            }
+            LAUNCH_PARAM launchParam;
+            launchParam.beginFrame = nFrame;
+            launchParam.endFrame = nFrame;
+            launchParam.projectFps = timeline()->fps();
+            AppHelper::initLaunchCacheParam(launchParam);
+            view->onRun(launchParam);
         }
     });
 }
@@ -788,7 +761,7 @@ void ZenoMainWindow::toggleTimelinePlay(bool bOn)
     m_pTimeline->togglePlayButton(bOn);
 }
 
-void ZenoMainWindow::onRunTriggered(bool applyLightAndCameraOnly, bool applyMaterialOnly)
+void ZenoMainWindow::onRunTriggered()
 {
     QVector<DisplayWidget*> views = viewports();
 
@@ -812,8 +785,6 @@ void ZenoMainWindow::onRunTriggered(bool applyLightAndCameraOnly, bool applyMate
         LAUNCH_PARAM launchParam;
         launchParam.beginFrame = beginFrame;
         launchParam.endFrame = endFrame;
-        launchParam.applyLightAndCameraOnly = applyLightAndCameraOnly;
-        launchParam.applyMaterialOnly = applyMaterialOnly;
         QString path = pModel->filePath();
         path = path.left(path.lastIndexOf("/"));
         launchParam.zsgPath = path;
@@ -2030,25 +2001,12 @@ bool ZenoMainWindow::isAlways() const
     return m_bAlways;
 }
 
-bool ZenoMainWindow::isAlwaysLightCamera() const {
-    return m_bAlwaysLightCamera;
-}
-
-bool ZenoMainWindow::isAlwaysMaterial() const {
-    return m_bAlwaysMaterial;
-}
-
 void ZenoMainWindow::setAlways(bool bAlways)
 {
     m_bAlways = bAlways;
     emit alwaysModeChanged(bAlways);
     if (m_bAlways)
         m_pTimeline->togglePlayButton(false);
-}
-
-void ZenoMainWindow::setAlwaysLightCameraMaterial(bool bAlwaysLightCamera, bool bAlwaysMaterial) {
-    m_bAlwaysLightCamera = bAlwaysLightCamera;
-    m_bAlwaysMaterial = bAlwaysMaterial;
 }
 
 void ZenoMainWindow::resetTimeline(TIMELINE_INFO info)

--- a/ui/zenoedit/zenomainwindow.h
+++ b/ui/zenoedit/zenomainwindow.h
@@ -38,10 +38,7 @@ public:
     void setInDlgEventLoop(bool bOn);
     TIMELINE_INFO timelineInfo();
     void setAlways(bool bAlways);
-    void setAlwaysLightCameraMaterial(bool bAlwaysLightCamera, bool bAlwaysMaterial);
     bool isAlways() const;
-    bool isAlwaysLightCamera() const;
-    bool isAlwaysMaterial() const;
     void resetTimeline(TIMELINE_INFO info);
     void initUserdata(USERDATA_SETTING info);
     ZTimeline* timeline() const;
@@ -167,7 +164,7 @@ public slots:
     void optixClientRun(int port, const char* cachedir, int cachenum, int sFrame, int eFrame, int finishedFrames, const char* sessionId);
     void optixClientSend(QString& info);
     void optixClientStartRec();
-    void onRunTriggered(bool applyLightAndCameraOnly = false, bool applyMaterialOnly = false);
+    void onRunTriggered();
     void updateNativeWinTitle(const QString& title);
     void toggleTimelinePlay(bool bOn);
     void onZenovisFrameUpdate(bool bGLView, int frameid);
@@ -216,8 +213,6 @@ private:
     PtrLayoutNode m_layoutRoot;
     bool m_bInDlgEventloop;
     bool m_bAlways;
-    bool m_bAlwaysLightCamera;
-    bool m_bAlwaysMaterial;
     int m_nResizeTimes;
     bool m_bOnlyOptix;          //isolate optix window.
     Ui::MainWindow* m_ui;

--- a/ui/zenomodel/include/igraphsmodel.h
+++ b/ui/zenomodel/include/igraphsmodel.h
@@ -120,7 +120,7 @@ public:
     virtual void setApiRunningEnable(bool bEnable) = 0;
     virtual bool isApiRunningEnable() const = 0;
     virtual bool setCustomName(const QModelIndex &subgIdx, const QModelIndex& Idx, const QString &value) const = 0;
-    virtual void markNodeDataChanged(const QModelIndex& idx) = 0;
+    virtual void markNodeDataChanged(const QModelIndex& idx, bool recursively = true) = 0;
     virtual void clearNodeDataChanged() = 0;
     virtual QStringList subgraphsName() const = 0;
 

--- a/ui/zenomodel/src/graphsmodel.h
+++ b/ui/zenomodel/src/graphsmodel.h
@@ -142,7 +142,7 @@ public:
     void setApiRunningEnable(bool bEnable) override;
     bool isApiRunningEnable() const override;
     bool setCustomName(const QModelIndex &subgIdx, const QModelIndex &Idx, const QString &value) const override;
-    void markNodeDataChanged(const QModelIndex& idx) override;
+    void markNodeDataChanged(const QModelIndex& idx, bool recursively = true) override;
     void markNotDescNode() override;
     bool hasNotDescNode() const override;
     void clearNodeDataChanged() override;
@@ -184,7 +184,7 @@ public slots:
 
 private:
     NODE_DESCS getCoreDescs();
-    void _markNodeChanged(const QModelIndex& idx);
+    void _markNodeChanged(const QModelIndex& idx, bool recursively = true);
     void _markSubnodesChange(SubGraphModel* pSubg);
     void _findReference(
         const QString& subgraphName,

--- a/ui/zenomodel/src/modelacceptor.cpp
+++ b/ui/zenomodel/src/modelacceptor.cpp
@@ -1040,6 +1040,7 @@ void ModelAcceptor::setOptions(const QString& id, const QStringList& options)
         else if (optName == "VIEW")
         {
             opts |= OPT_VIEW;
+            opts |= OPT_CACHE;
         }
         else if (optName == "MUTE")
         {

--- a/ui/zenoui/comctrl/ztoolmenubutton.cpp
+++ b/ui/zenoui/comctrl/ztoolmenubutton.cpp
@@ -34,7 +34,7 @@ ZToolMenuButton::ZToolMenuButton(QWidget* parent)
     : ZToolButton(parent)
 {
     setButtonOptions(ZToolButton::Opt_TextRightToIcon);
-    setArrowOption(ZStyleOptionToolButton::DOWNARROW);
+    //setArrowOption(ZStyleOptionToolButton::DOWNARROW);
     m_pMenu = new QMenu(this);
     m_pMenu->setProperty("cssClass", "menuButton");
     CustomIconStyle* pStyle = new CustomIconStyle;
@@ -54,20 +54,20 @@ void ZToolMenuButton::addAction(const QString& action, const QString& icon)
 }
 
 void ZToolMenuButton::mouseReleaseEvent(QMouseEvent* e) {
-    QSize size = ZToolButton::sizeHint();
-    if (e->x() >= (size.width() - ZenoStyle::dpiScaled(10)))
-    {
-        QPoint pos;
-        pos.setY(pos.y() + this->geometry().height());
-        m_pMenu->exec(this->mapToGlobal(pos));
-        return;
-    }
+    //QSize size = ZToolButton::sizeHint();
+    //if (e->x() >= (size.width() - ZenoStyle::dpiScaled(10)))
+    //{
+    //    QPoint pos;
+    //    pos.setY(pos.y() + this->geometry().height());
+    //    m_pMenu->exec(this->mapToGlobal(pos));
+    //    return;
+    //}
     emit clicked();
 }
 
 
 QSize ZToolMenuButton::sizeHint() const {
     QSize size = ZToolButton::sizeHint();
-    size.setWidth(size.width() + ZenoStyle::dpiScaled(12));
+    //size.setWidth(size.width() + ZenoStyle::dpiScaled(12));
     return size;
 }

--- a/zeno/include/zeno/core/Graph.h
+++ b/zeno/include/zeno/core/Graph.h
@@ -47,6 +47,8 @@ struct Graph : std::enable_shared_from_this<Graph> {
     std::unique_ptr<Context> ctx;
     std::unique_ptr<DirtyChecker> dirtyChecker;
 
+    bool runDirtyNodesOnly = true;
+
     ZENO_API Graph();
     ZENO_API ~Graph();
 

--- a/zeno/include/zeno/core/Graph.h
+++ b/zeno/include/zeno/core/Graph.h
@@ -47,8 +47,6 @@ struct Graph : std::enable_shared_from_this<Graph> {
     std::unique_ptr<Context> ctx;
     std::unique_ptr<DirtyChecker> dirtyChecker;
 
-    bool runDirtyNodesOnly = true;
-
     ZENO_API Graph();
     ZENO_API ~Graph();
 
@@ -82,6 +80,7 @@ struct Graph : std::enable_shared_from_this<Graph> {
     ZENO_API std::map<std::string, zany> callTempNode(std::string const &id,
             std::map<std::string, zany> inputs) const;
     ZENO_API void setTempCache(std::string const& id);
+    ZENO_API void setToView(std::string const& id, bool isStatic);
 };
 
 }

--- a/zeno/include/zeno/core/INode.h
+++ b/zeno/include/zeno/core/INode.h
@@ -35,6 +35,8 @@ public:
     zany muted_output;
 
     bool bTmpCache = false;
+    bool bIsToView = false;
+    bool isStatic = false;
 
     ZENO_API INode();
     ZENO_API virtual ~INode();

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -40,7 +40,7 @@ struct GlobalComm {
     ZENO_API void initFrameRange(int beg, int end);
     ZENO_API void newFrame();
     ZENO_API void finishFrame();
-    ZENO_API void dumpFrameCache(int frameid, bool cacheLightCameraOnly = false, bool cacheMaterialOnly = false);
+    ZENO_API void dumpFrameCache(int frameid);
     ZENO_API void addViewObject(std::string const &key, std::shared_ptr<IObject> object);
     ZENO_API int maxPlayFrames();
     ZENO_API int numOfFinishedFrame();
@@ -60,7 +60,7 @@ struct GlobalComm {
     ZENO_API std::string cachePath();
     ZENO_API bool removeCache(int frame);
     ZENO_API void removeCachePath();
-    static void toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, bool cacheLightCameraOnly, bool cacheMaterialOnly, std::string fileName = "");
+    static void toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string fileName = "");
     static bool fromDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string fileName = "");
 private:
     ViewObjects const *_getViewObjects(const int frameid);

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -42,7 +42,6 @@ struct GlobalComm {
     int maxCachedFrames = 1;
     std::string cacheFramePath;
     std::string objTmpCachePath;
-    int currentFrameNumber = 0;
 
     ZENO_API void frameCache(std::string const &path, int gcmax);
     ZENO_API void initFrameRange(int beg, int end);
@@ -123,6 +122,7 @@ private:
     std::map<std::string, int> lastToViewNodesType;
     //------new change------
     void prepareForOptix(bool inserted, std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);
+    int currentFrameIdx = 0;
     bool updateOptixByViewport = false;
     mutable std::recursive_mutex m_recur_mutex;
 };

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -76,10 +76,10 @@ struct GlobalComm {
     ZENO_API std::optional<zeno::IObject*> get(std::string nid);
     enum RenderType
     {
-        UNDEFINED = 0,
-        UPDATE_ALL,
-        UPDATE_LIGHT_CAMERA,
-        UPDATE_MATERIAL
+        NORMAL = 0,
+        LIGHT_CAMERA,
+        MATERIAL,
+        UNDEFINED,
     };
 
     ZENO_API std::vector<std::pair<std::string, IObject*>> pairs() const;
@@ -108,6 +108,9 @@ struct GlobalComm {
 
     ZENO_API const std::string getObjKey1(std::string& id, int frame);
 
+    ZENO_API RenderType getRenderTypeByObjects(std::map<std::string, zeno::IObject*> objs);
+    ZENO_API void updateObjsIdByViewport(std::map<std::string, zeno::IObject*>& objsToBeUpdate);
+
 private:
     ViewObjects const* _getViewObjects(const int frameid);
     std::vector<std::string> toViewNodesId;
@@ -116,11 +119,11 @@ private:
     std::map<std::string, std::shared_ptr<zeno::IObject>> lightObjects;
     bool needUpdateLight = true;
 
-    void prepareForOptix(bool inserted, std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);  //determine update type accord to objs changes
-    void determineRenderType(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);
     RenderType renderType = UNDEFINED;
     std::map<std::string, int> lastToViewNodesType;
     //------new change------
+    void prepareForOptix(bool inserted, std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);
+    bool updateOptixByViewport = false;
     mutable std::recursive_mutex m_recur_mutex;
 };
 

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -10,11 +10,14 @@
 #include <set>
 #include <functional>
 #include <filesystem>
+#include <zeno/extra/ObjectsManager.h>
 
 namespace zeno {
 
 struct GlobalComm {
     using ViewObjects = PolymorphicMap<std::map<std::string, std::shared_ptr<IObject>>>;
+
+    std::unique_ptr<ObjectsManager> objectsMan = std::make_unique<ObjectsManager>();
 
     enum FRAME_STATE {
         FRAME_UNFINISH,

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -11,13 +11,16 @@
 #include <functional>
 #include <filesystem>
 #include <zeno/extra/ObjectsManager.h>
+//-----ObjectsManager-----
+#include <zeno/utils/MapStablizer.h>
+#include <zeno/utils/disable_copy.h>
+#include <optional>
+#include "zeno/utils/vec.h"
 
 namespace zeno {
 
 struct GlobalComm {
     using ViewObjects = PolymorphicMap<std::map<std::string, std::shared_ptr<IObject>>>;
-
-    std::unique_ptr<ObjectsManager> objectsMan = std::make_unique<ObjectsManager>();
 
     enum FRAME_STATE {
         FRAME_UNFINISH,
@@ -54,9 +57,7 @@ struct GlobalComm {
     ZENO_API void clearFrameState();
     ZENO_API ViewObjects const *getViewObjects(const int frameid);
     ZENO_API ViewObjects const &getViewObjects();
-    ZENO_API bool load_objects(const int frameid, 
-                const std::function<bool(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs)>& cb,
-                bool& isFrameValid);
+    ZENO_API bool load_objects(const int frameid, bool& isFrameValid);
     ZENO_API bool isFrameCompleted(int frameid) const;
     ZENO_API FRAME_STATE getFrameState(int frameid) const;
     ZENO_API bool isFrameBroken(int frameid) const;
@@ -71,6 +72,68 @@ struct GlobalComm {
 private:
     ViewObjects const *_getViewObjects(const int frameid);
     std::vector<std::string> toViewNodesId;
+
+//-------------------integrate objectsManager----------------------
+public:
+    //-----ObjectsManager-----
+    ZENO_API void clear_objects();
+    ZENO_API std::optional<zeno::IObject*> get(std::string nid);
+    enum RenderType
+    {
+        UNDEFINED = 0,
+        UPDATE_ALL,
+        UPDATE_LIGHT_CAMERA,
+        UPDATE_MATERIAL
+    };
+
+    template <class T = void>
+    auto pairs() const {
+        std::lock_guard lck(m_recur_mutex);
+        return objects.pairs<T>();
+    }
+    template <class T = void>
+    auto pairsShared() const {
+        std::lock_guard lck(m_recur_mutex);
+        return objects.pairsShared<T>();
+    }
+
+    //------new change------
+    ZENO_API void clear_lightObjects();
+    ZENO_API bool lightObjsCount(std::string& id);
+    ZENO_API bool objsCount(std::string& id);
+    ZENO_API const std::string getLightObjKeyByLightObjID(std::string id);
+    ZENO_API const std::string getObjKeyByObjID(std::string& id);
+    ZENO_API bool getLightObjData(std::string& id, zeno::vec3f& pos, zeno::vec3f& scale, zeno::vec3f& rotate, zeno::vec3f& clr, float& intensity);
+    ZENO_API bool setLightObjData(std::string& id, zeno::vec3f& pos, zeno::vec3f& scale, zeno::vec3f& rotate, zeno::vec3f& rgb, float& intensity, std::vector<zeno::vec3f>& verts);
+    ZENO_API bool setProceduralSkyData(std::string id, zeno::vec2f& sunLightDir, float& sunSoftnessValue, zeno::vec2f& windDir, float& timeStartValue, float& timeSpeedValue, float& sunLightIntensityValue, float& colorTemperatureMixValue, float& colorTemperatureValue);
+    ZENO_API bool getProceduralSkyData(std::string& id, zeno::vec2f& sunLightDir, float& sunSoftnessValue, zeno::vec2f& windDir, float& timeStartValue, float& timeSpeedValue, float& sunLightIntensityValue, float& colorTemperatureMixValue, float& colorTemperatureValue);
+    ZENO_API void getAllLightsKey(std::vector<std::string>& keys);
+    ZENO_API std::string getObjMatId(std::string& id);
+    ZENO_API void setRenderType(RenderType type);
+    ZENO_API RenderType getRenderType();
+
+    ZENO_API std::map<std::string, std::shared_ptr<zeno::IObject>>& getLightObjs();
+    ZENO_API int getLightObjsSize();
+    ZENO_API bool getNeedUpdateLight();
+    ZENO_API void setNeedUpdateLight(bool update);
+
+    ZENO_API void mutexCallback(const std::function<void()>& callback);
+
+    ZENO_API const std::string getObjKey1(std::string& id, int frame);
+private:
+    //-----ObjectsManager-----
+    std::map<std::string, std::shared_ptr<zeno::IObject>> lightObjects;
+    zeno::MapStablizer<zeno::PolymorphicMap<std::map<std::string, std::shared_ptr<zeno::IObject>>>> objects;
+    bool needUpdateLight = true;
+
+    bool load_objectsToManager(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);  //determine update type accord to objs changes
+    void determineRenderType(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);
+    RenderType renderType = UNDEFINED;
+    std::map<std::string, int> lastToViewNodesType;
+
+    //------new change------
+    mutable std::recursive_mutex m_recur_mutex;
+
 };
 
 }

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <set>
 #include <functional>
+#include <filesystem>
 
 namespace zeno {
 
@@ -60,10 +61,13 @@ struct GlobalComm {
     ZENO_API std::string cachePath();
     ZENO_API bool removeCache(int frame);
     ZENO_API void removeCachePath();
-    static void toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string fileName = "");
-    static bool fromDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string fileName = "");
+    ZENO_API void setToViewNodes(std::vector<std::string>& nodes);
+    static void toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string key = "", bool dumpCacheVersionInfo = false);
+    static bool fromDiskByRunner(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::string filename);
+    static bool fromDiskByObjsManager(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::vector<std::string>& nodesToLoad);
 private:
     ViewObjects const *_getViewObjects(const int frameid);
+    std::vector<std::string> toViewNodesId;
 };
 
 }

--- a/zeno/include/zeno/extra/ObjectsManager.h
+++ b/zeno/include/zeno/extra/ObjectsManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <zenovis/Scene.h>
 #include <zeno/utils/MapStablizer.h>
 #include <zeno/utils/PolymorphicMap.h>
 #include <zeno/utils/disable_copy.h>
@@ -9,10 +8,11 @@
 #include <memory>
 #include <map>
 #include <set>
+#include <optional>
 
-namespace zenovis {
+namespace zeno {
 
-struct ObjectsManager : zeno::disable_copy {
+struct ObjectsManager {
     zeno::MapStablizer<zeno::PolymorphicMap<std::map<
         std::string, std::shared_ptr<zeno::IObject>>>> objects;
 
@@ -31,10 +31,10 @@ struct ObjectsManager : zeno::disable_copy {
 
     ObjectsManager();
     ~ObjectsManager();
-    void clear_objects();
     bool load_objects(std::map<std::string, std::shared_ptr<zeno::IObject>> const &objs);
 
-    std::optional<zeno::IObject*> get(std::string nid);
+    ZENO_API void clear_objects();
+    ZENO_API std::optional<zeno::IObject*> get(std::string nid);
 
     //---determine update type accord to objs changes---
     enum RenderType

--- a/zeno/src/core/Graph.cpp
+++ b/zeno/src/core/Graph.cpp
@@ -71,15 +71,12 @@ ZENO_API Graph *Graph::getSubnetGraph(std::string const &id) const {
 }
 
 ZENO_API void Graph::completeNode(std::string const &id) {
-    if (runDirtyNodesOnly)
-    {
-        if (id.substr(id.find(":") + 1) != "TOVIEW")    //complete all nodes except toview node
-            safe_at(nodes, id, "node name")->doComplete();
-        else if (id.substr(id.find(":") + 1) == "TOVIEW" && getDirtyChecker().amIDirty(id.substr(0, id.find(":"))))    //only complete dirty toview node
-            safe_at(nodes, id, "node name")->doComplete();
-    }
-    else {
+    if (!safe_at(nodes, id, "node name")->bIsToView)    //complete all nodes except toview node
         safe_at(nodes, id, "node name")->doComplete();
+    else if (safe_at(nodes, id, "node name")->bIsToView && getDirtyChecker().amIDirty(id.substr(0, id.find(":"))))    //only complete dirty toview node
+    {
+        safe_at(nodes, id, "node name")->doComplete();
+        nodesToExec.insert(safe_at(nodes, id, "node name")->myname);
     }
 }
 
@@ -157,6 +154,12 @@ ZENO_API std::map<std::string, zany> Graph::callTempNode(std::string const &id,
 ZENO_API void Graph::setTempCache(std::string const& id)
 {
     safe_at(nodes, id, "node name")->bTmpCache = true;
+}
+
+ZENO_API void Graph::setToView(std::string const& id, bool isStatic)
+{
+    safe_at(nodes, id, "node name")->bIsToView = true;
+    safe_at(nodes, id, "node name")->isStatic = isStatic;
 }
 
 ZENO_API void Graph::addNodeOutput(std::string const& id, std::string const& par) {

--- a/zeno/src/core/Graph.cpp
+++ b/zeno/src/core/Graph.cpp
@@ -71,7 +71,13 @@ ZENO_API Graph *Graph::getSubnetGraph(std::string const &id) const {
 }
 
 ZENO_API void Graph::completeNode(std::string const &id) {
-    safe_at(nodes, id, "node name")->doComplete();
+    if (id.substr(id.find(":") + 1) != "TOVIEW")    //complete all nodes except toview node
+    {
+        safe_at(nodes, id, "node name")->doComplete();
+    }else if (id.substr(id.find(":") + 1) == "TOVIEW" && getDirtyChecker().amIDirty(id.substr(0, id.find(":"))))    //only complete dirty toview node
+    {
+        safe_at(nodes, id, "node name")->doComplete();
+    }
 }
 
 ZENO_API bool Graph::applyNode(std::string const &id) {

--- a/zeno/src/core/Graph.cpp
+++ b/zeno/src/core/Graph.cpp
@@ -71,11 +71,14 @@ ZENO_API Graph *Graph::getSubnetGraph(std::string const &id) const {
 }
 
 ZENO_API void Graph::completeNode(std::string const &id) {
-    if (id.substr(id.find(":") + 1) != "TOVIEW")    //complete all nodes except toview node
+    if (runDirtyNodesOnly)
     {
-        safe_at(nodes, id, "node name")->doComplete();
-    }else if (id.substr(id.find(":") + 1) == "TOVIEW" && getDirtyChecker().amIDirty(id.substr(0, id.find(":"))))    //only complete dirty toview node
-    {
+        if (id.substr(id.find(":") + 1) != "TOVIEW")    //complete all nodes except toview node
+            safe_at(nodes, id, "node name")->doComplete();
+        else if (id.substr(id.find(":") + 1) == "TOVIEW" && getDirtyChecker().amIDirty(id.substr(0, id.find(":"))))    //only complete dirty toview node
+            safe_at(nodes, id, "node name")->doComplete();
+    }
+    else {
         safe_at(nodes, id, "node name")->doComplete();
     }
 }

--- a/zeno/src/core/INode.cpp
+++ b/zeno/src/core/INode.cpp
@@ -75,9 +75,8 @@ ZENO_API void INode::complete() {}
 ZENO_API bool zeno::INode::getTmpCache()
 {
     GlobalComm::ViewObjects objs;
-    std::string fileName = myname + ".zenocache";
     int frameid = zeno::getSession().globalState->frameid;
-    bool ret = GlobalComm::fromDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, fileName);
+    bool ret = GlobalComm::fromDiskByRunner(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, myname);
     if (ret && objs.size() > 0)
     {
         for (const auto& [key, obj] : objs)
@@ -106,8 +105,19 @@ ZENO_API void zeno::INode::writeTmpCaches()
 
     }
     int frameid = zeno::getSession().globalState->frameid;
-    std::string fileName = myname + ".zenocache";
-    GlobalComm::toDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, fileName);
+
+    {   //store cache version
+        auto key = myname;
+        key.push_back(':');
+        if (isStatic)
+            key.append("static");
+        else
+            key.append(std::to_string(getThisSession()->globalState->frameid));
+        key.push_back(':');
+        key.append(std::to_string(getThisSession()->globalState->sessionid));
+        getThisSession()->globalComm->addViewObject(key, std::make_shared<IObject>());
+    }
+    GlobalComm::toDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, myname, false);
 }
 
 ZENO_API void INode::preApply() {
@@ -119,7 +129,7 @@ ZENO_API void INode::preApply() {
     }
     else if (dc.amIDirty(myname) && !bTmpCache)//remove cache
     {
-        std::string fileName = myname + ".zenocache";
+        std::string fileName = myname + ".zencache";
         int frameid = zeno::getSession().globalState->frameid;
         const auto& path = std::filesystem::u8path(zeno::getSession().globalComm->objTmpCachePath + "/" + std::to_string(1000000 + frameid).substr(1) + "/" + fileName);
         if (std::filesystem::exists(path))
@@ -140,7 +150,7 @@ ZENO_API void INode::preApply() {
         apply();
         if (bTmpCache)
             writeTmpCaches();
-    }
+        }
     log_debug("==> leave {}", myname);
 }
 

--- a/zeno/src/core/INode.cpp
+++ b/zeno/src/core/INode.cpp
@@ -107,7 +107,7 @@ ZENO_API void zeno::INode::writeTmpCaches()
     }
     int frameid = zeno::getSession().globalState->frameid;
     std::string fileName = myname + ".zenocache";
-    GlobalComm::toDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, false, false, fileName);
+    GlobalComm::toDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, fileName);
 }
 
 ZENO_API void INode::preApply() {

--- a/zeno/src/core/loadGraph.cpp
+++ b/zeno/src/core/loadGraph.cpp
@@ -124,8 +124,8 @@ ZENO_API void Graph::loadGraph(const char *json) {
                 //todo: mark node data change.
             } else if (cmd == "cacheToDisk") {
                 g->setTempCache(di[1].GetString());
-            } else if (cmd == "runDirtyNodesOnly") {
-                this->runDirtyNodesOnly = di[1].GetBool();
+            } else if (cmd == "setToView") {
+                g->setToView(di[1].GetString(), di[3].GetBool());
             } else {
                 log_warn("got unexpected command: {}", cmd);
             }

--- a/zeno/src/core/loadGraph.cpp
+++ b/zeno/src/core/loadGraph.cpp
@@ -124,6 +124,8 @@ ZENO_API void Graph::loadGraph(const char *json) {
                 //todo: mark node data change.
             } else if (cmd == "cacheToDisk") {
                 g->setTempCache(di[1].GetString());
+            } else if (cmd == "runDirtyNodesOnly") {
+                this->runDirtyNodesOnly = di[1].GetBool();
             } else {
                 log_warn("got unexpected command: {}", cmd);
             }

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -18,7 +18,7 @@
 
 namespace zeno {
 
-void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, bool cacheLightCameraOnly, bool cacheMaterialOnly, std::string fileName) {
+void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string fileName) {
     if (cachedir.empty()) return;
     std::filesystem::path dir = std::filesystem::u8path(cachedir + "/" + std::to_string(1000000 + frameid).substr(1));
     if (!std::filesystem::exists(dir) && !std::filesystem::create_directories(dir))
@@ -165,12 +165,12 @@ ZENO_API void GlobalComm::finishFrame() {
     m_maxPlayFrame += 1;
 }
 
-ZENO_API void GlobalComm::dumpFrameCache(int frameid, bool cacheLightCameraOnly, bool cacheMaterialOnly) {
+ZENO_API void GlobalComm::dumpFrameCache(int frameid) {
     std::lock_guard lck(m_mtx);
     int frameIdx = frameid - beginFrameNumber;
     if (frameIdx >= 0 && frameIdx < m_frames.size()) {
         log_debug("dumping frame {}", frameid);
-        toDisk(cacheFramePath, frameid, m_frames[frameIdx].view_objects, cacheLightCameraOnly, cacheMaterialOnly);
+        toDisk(cacheFramePath, frameid, m_frames[frameIdx].view_objects);
     }
 }
 

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -2,7 +2,6 @@
 #include <zeno/extra/GlobalState.h>
 #include <zeno/funcs/ObjectCodec.h>
 #include <zeno/utils/log.h>
-#include <filesystem>
 #include <algorithm>
 #include <fstream>
 #include <cassert>
@@ -10,6 +9,7 @@
 #include <unordered_set>
 #include <zeno/types/MaterialObject.h>
 #include <zeno/types/CameraObject.h>
+#include <zeno/types/ListObject.h>
 #ifdef __linux__
     #include<unistd.h>
     #include <sys/statfs.h>
@@ -18,78 +18,124 @@
 
 namespace zeno {
 
-void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string fileName) {
+void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string key, bool dumpCacheVersionInfo) {
     if (cachedir.empty()) return;
+
     std::filesystem::path dir = std::filesystem::u8path(cachedir + "/" + std::to_string(1000000 + frameid).substr(1));
     if (!std::filesystem::exists(dir) && !std::filesystem::create_directories(dir))
     {
         log_critical("can not create path: {}", dir);
     }
-    std::vector<std::filesystem::path> cachepath(objs.size());
-
-    std::vector<std::vector<char>> bufCaches(objs.size());
-    std::vector<std::vector<size_t>> poses(objs.size());
-    std::vector<std::string> keys(objs.size());
-    size_t objCount = 0;
-    for (auto const &[key, obj]: objs) {
-        if (encodeObject(obj.get(), bufCaches[objCount]))
-        {
-            keys[objCount].push_back('\a');
-            keys[objCount].append(key);
-            poses[objCount].push_back(0);
-            if (fileName != "")
-                cachepath[objCount] = std::filesystem::u8path(dir.string() + "/" + fileName);   //tmp zenocache
-            else
-                cachepath[objCount] = dir / (key.substr(0, key.find(":")) + ".zencache");
-
-            objCount++;
-        }
-    }
-
-    size_t currentFrameSize = 0;
-    for (int i = 0; i < objs.size(); i++)
+    if (dumpCacheVersionInfo)
     {
-        keys[i].push_back('\a');
-        keys[i] = "ZENCACHE" + std::to_string(1) + keys[i];
-        poses[i].push_back(bufCaches[i].size());
-        currentFrameSize += keys[i].size() + 1 * sizeof(size_t) + bufCaches[i].size();
+        std::map<std::string, std::string> toViewNodesInfo;
+
+        std::filesystem::path toViewInfoPath = dir / "toViewInofs.zencache";
+        if (std::filesystem::exists(toViewInfoPath))
+        {
+            auto szBuffer = std::filesystem::file_size(toViewInfoPath);
+            if (szBuffer != 0)
+            {
+                std::vector<char> dat(szBuffer);
+                FILE* fp = fopen(toViewInfoPath.string().c_str(), "rb");
+                if (!fp) {
+                    log_error("zeno cache file does not exist");
+                    return;
+                }
+                size_t ret = fread(&dat[0], 1, szBuffer, fp);
+                assert(ret == szBuffer);
+                fclose(fp);
+                fp = nullptr;
+
+                size_t beginpos = 0;
+                size_t keyLen = 0;
+                std::vector<char>::iterator beginIterator = dat.begin();
+                for (auto i = dat.begin(); i != dat.end(); i++)
+                {
+                    if (*i == '\a')
+                    {
+                        keyLen = i - beginIterator;
+                        std::string key(dat.data() + beginpos, keyLen);
+                        toViewNodesInfo.insert(std::make_pair(std::move(key.substr(0, key.find(":"))), std::move(key)));
+                        beginpos += i - beginIterator + 1;
+                        beginIterator = i + 1;
+                    }
+                }
+            }
+        }
+        for (auto const& [key, obj] : objs) {
+            if (toViewNodesInfo.count(key.substr(0, key.find(":")))) {
+                toViewNodesInfo[key.substr(0, key.find(":"))] = key;
+            }
+            toViewNodesInfo.insert(std::make_pair(key.substr(0, key.find(":")), key));
+        }
+        std::string keys;
+        for (auto const& [id, key] : toViewNodesInfo) {
+            keys.append(key);
+            keys.push_back('\a');
+        }
+        std::ofstream ofs(toViewInfoPath, std::ios::binary);
+        std::ostreambuf_iterator<char> oit(ofs);
+        std::copy(keys.begin(), keys.end(), oit);
     }
-    size_t freeSpace = 0;
-    #ifdef __linux__
+    else {
+        std::filesystem::path cachepath = dir / (key + ".zencache");
+        std::vector<char> bufCaches;
+        std::vector<size_t> poses;
+        std::string keys;
+        for (auto const& [key, obj] : objs) {
+            size_t bufsize = bufCaches.size();
+
+            std::back_insert_iterator<std::vector<char>> it(bufCaches);
+            if (encodeObject(obj.get(), bufCaches))
+            {
+                keys.push_back('\a');
+                keys.append(key);
+                poses.push_back(bufsize);
+            }
+        }
+        keys.push_back('\a');
+        keys = "ZENCACHE" + std::to_string(poses.size()) + keys;
+        poses.push_back(bufCaches.size());
+        size_t currentFrameSize = keys.size() + poses.size() * sizeof(size_t) + bufCaches.size();
+
+        size_t freeSpace = 0;
+#ifdef __linux__
         struct statfs diskInfo;
         statfs(std::filesystem::u8path(cachedir).c_str(), &diskInfo);
         freeSpace = diskInfo.f_bsize * diskInfo.f_bavail;
-    #else
+#else
         freeSpace = std::filesystem::space(std::filesystem::u8path(cachedir)).free;
-    #endif
-    //wait in two case: 1. available space minus current frame size less than 1024MB, 2. available space less or equal than 1024MB
-    while ( ((freeSpace >> 20) - MIN_DISKSPACE_MB) < (currentFrameSize >> 20)  || (freeSpace >> 20) <= MIN_DISKSPACE_MB)
-    {
-        #ifdef __linux__
+#endif
+        //wait in two case: 1. available space minus current frame size less than 1024MB, 2. available space less or equal than 1024MB
+        while (((freeSpace >> 20) - MIN_DISKSPACE_MB) < (currentFrameSize >> 20) || (freeSpace >> 20) <= MIN_DISKSPACE_MB)
+        {
+#ifdef __linux__
             zeno::log_critical("Disk space almost full on {}, wait for zencache remove", std::filesystem::u8path(cachedir).string());
             sleep(2);
             statfs(std::filesystem::u8path(cachedir).c_str(), &diskInfo);
             freeSpace = diskInfo.f_bsize * diskInfo.f_bavail;
 
-        #else
+#else
             zeno::log_critical("Disk space almost full on {}, wait for zencache remove", std::filesystem::u8path(cachedir).root_path().string());
             std::this_thread::sleep_for(std::chrono::milliseconds(2000));
             freeSpace = std::filesystem::space(std::filesystem::u8path(cachedir)).free;
-        #endif
-    }
-    for (int i = 0; i < objs.size(); i++)
-    {
-        log_debug("dump cache to disk {}", cachepath[i]);
-        std::ofstream ofs(cachepath[i], std::ios::binary);
+#endif
+        }
+
+        log_debug("dump cache to disk {}", cachepath);
+        std::ofstream ofs(cachepath, std::ios::binary);
         std::ostreambuf_iterator<char> oit(ofs);
-        std::copy(keys[i].begin(), keys[i].end(), oit);
-        std::copy_n((const char *)poses[i].data(), poses[i].size() * sizeof(size_t), oit);
-        std::copy(bufCaches[i].begin(), bufCaches[i].end(), oit);
+        std::copy(keys.begin(), keys.end(), oit);
+        std::copy_n((const char*)poses.data(), poses.size() * sizeof(size_t), oit);
+        std::copy(bufCaches.begin(), bufCaches.end(), oit);
     }
+    
     objs.clear();
 }
 
-bool GlobalComm::fromDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string fileName) {
+bool GlobalComm::fromDiskByObjsManager(std::string cachedir, int frameid, GlobalComm::ViewObjects& objs, std::vector<std::string>& nodesToLoad)
+{
     if (cachedir.empty())
         return false;
     objs.clear();
@@ -97,15 +143,74 @@ bool GlobalComm::fromDisk(std::string cachedir, int frameid, GlobalComm::ViewObj
     if (!std::filesystem::exists(dir))
         return false;
 
-    for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(dir)) {
-        std::filesystem::path filePath = entry.path();
-        if (!std::filesystem::is_directory(filePath) && std::filesystem::exists(filePath)) {
+    std::map<std::string, std::string> toViewNodesInfo;
 
-            log_debug("load cache from disk {}", filePath);
+    std::filesystem::path filePath = dir / "toViewInofs.zencache";
+    if (!std::filesystem::is_directory(filePath) && std::filesystem::exists(filePath)) {
+        auto szBuffer = std::filesystem::file_size(filePath);
+        if (szBuffer == 0)
+            return true;
 
-            auto szBuffer = std::filesystem::file_size(filePath);
+        std::vector<char> dat(szBuffer);
+        FILE* fp = fopen(filePath.string().c_str(), "rb");
+        if (!fp) {
+            log_error("zeno cache file does not exist");
+            return false;
+        }
+        size_t ret = fread(&dat[0], 1, szBuffer, fp);
+        assert(ret == szBuffer);
+        fclose(fp);
+        fp = nullptr;
+
+        size_t beginpos = 0;
+        size_t keyLen = 0;
+        std::vector<char>::iterator beginIterator = dat.begin();
+        for (auto i = dat.begin(); i != dat.end(); i++)
+        {
+            if (*i == '\a')
+            {
+                keyLen = i - beginIterator;
+                std::string key(dat.data() + beginpos, keyLen);
+                toViewNodesInfo.insert(std::make_pair(std::move(key.substr(0, key.find(":"))), std::move(key)));
+                beginpos += i - beginIterator + 1;
+                beginIterator = i + 1;
+            }
+        }
+    }
+
+    std::function<void(zany const&, std::string, std::string)> convertToView = [&](zany const& p, std::string postfix, std::string name) -> void {
+        if (ListObject* lst = dynamic_cast<ListObject*>(p.get())) {
+            log_info("ToView got ListObject (size={}), expanding", lst->arr.size());
+            for (size_t i = 0; i < lst->arr.size(); i++) {
+                zany const& lp = lst->arr[i];
+                std::string id(name);
+                convertToView(lp, postfix + ":LIST" + std::to_string(i), id.insert(id.find(":"), postfix + ":LIST:" + std::to_string(i)));
+            }
+            return;
+        }
+        if (!p) {
+            log_error("ToView: given object is nullptr");
+        }
+        else {
+            objs.try_emplace(name, std::move(p));
+        }
+    };
+    for (auto& cache : nodesToLoad)
+    {
+        if (toViewNodesInfo.find(cache) == toViewNodesInfo.end())
+            continue;
+        std::string toViewObjInfo = toViewNodesInfo[cache];
+
+        std::filesystem::path cachePath = dir / (cache + ".zencache");
+        if (!std::filesystem::is_directory(cachePath) && std::filesystem::exists(cachePath)) {
+            auto szBuffer = std::filesystem::file_size(cachePath);
+            if (szBuffer == 0)
+                return true;
+
+            log_debug("load cache from disk {}", cachePath);
+
             std::vector<char> dat(szBuffer);
-            FILE* fp = fopen(filePath.string().c_str(), "rb");
+            FILE* fp = fopen(cachePath.string().c_str(), "rb");
             if (!fp) {
                 log_error("zeno cache file does not exist");
                 return false;
@@ -139,13 +244,77 @@ bool GlobalComm::fromDisk(std::string cachedir, int frameid, GlobalComm::ViewObj
             std::vector<size_t> poses(keyscount + 1);
             std::copy_n(dat.data() + pos, (keyscount + 1) * sizeof(size_t), (char*)poses.data());
             pos += (keyscount + 1) * sizeof(size_t);
-            for (int k = 0; k < keyscount; k++) {
-                if (poses[k] > dat.size() - pos || poses[k + 1] < poses[k]) {
-                    log_error("zeno cache file broken (4.{})", k);
-                }
-                const char* p = dat.data() + pos + poses[k];
-                objs.try_emplace(keys[k], decodeObject(p, poses[k + 1] - poses[k]));
+
+            int lastObjIdx = keyscount - 1; //now only first output is needed to view this obj.
+            if (poses[lastObjIdx] > dat.size() - pos || poses[lastObjIdx + 1] < poses[lastObjIdx]) {
+                log_error("zeno cache file broken (4.{})", lastObjIdx);
             }
+            const char* p = dat.data() + pos + poses[lastObjIdx];
+
+            convertToView(decodeObject(p, poses[lastObjIdx + 1] - poses[lastObjIdx]), {}, toViewObjInfo.insert(toViewObjInfo.find(":"), ":TOVIEW"));
+        }
+    }
+    return true;
+}
+
+bool GlobalComm::fromDiskByRunner(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string filename) {
+    if (cachedir.empty())
+        return false;
+    objs.clear();
+    auto dir = std::filesystem::u8path(cachedir) / std::to_string(1000000 + frameid).substr(1);
+    if (!std::filesystem::exists(dir))
+        return false;
+
+    std::filesystem::path filePath = dir / (filename + ".zencache");
+    if (!std::filesystem::is_directory(filePath) && std::filesystem::exists(filePath)) {
+
+        auto szBuffer = std::filesystem::file_size(filePath);
+        if (szBuffer == 0)
+            return true;
+
+        log_debug("load cache from disk {}", filePath);
+
+        std::vector<char> dat(szBuffer);
+        FILE* fp = fopen(filePath.string().c_str(), "rb");
+        if (!fp) {
+            log_error("zeno cache file does not exist");
+            return false;
+        }
+        size_t ret = fread(&dat[0], 1, szBuffer, fp);
+        assert(ret == szBuffer);
+        fclose(fp);
+        fp = nullptr;
+
+        if (dat.size() <= 8 || std::string(dat.data(), 8) != "ZENCACHE") {
+            log_error("zeno cache file broken (1)");
+            return false;
+        }
+        size_t pos = std::find(dat.begin() + 8, dat.end(), '\a') - dat.begin();
+        if (pos == dat.size()) {
+            log_error("zeno cache file broken (2)");
+            return false;
+        }
+        size_t keyscount = std::stoi(std::string(dat.data() + 8, pos - 8));
+        pos = pos + 1;
+        std::vector<std::string> keys;
+        for (int k = 0; k < keyscount; k++) {
+            size_t newpos = std::find(dat.begin() + pos, dat.end(), '\a') - dat.begin();
+            if (newpos == dat.size()) {
+                log_error("zeno cache file broken (3.{})", k);
+                return false;
+            }
+            keys.emplace_back(dat.data() + pos, newpos - pos);
+            pos = newpos + 1;
+        }
+        std::vector<size_t> poses(keyscount + 1);
+        std::copy_n(dat.data() + pos, (keyscount + 1) * sizeof(size_t), (char*)poses.data());
+        pos += (keyscount + 1) * sizeof(size_t);
+        for (int k = 0; k < keyscount; k++) {
+            if (poses[k] > dat.size() - pos || poses[k + 1] < poses[k]) {
+                log_error("zeno cache file broken (4.{})", k);
+            }
+            const char* p = dat.data() + pos + poses[k];
+            objs.try_emplace(keys[k], decodeObject(p, poses[k + 1] - poses[k]));
         }
     }
     return true;
@@ -170,7 +339,7 @@ ZENO_API void GlobalComm::dumpFrameCache(int frameid) {
     int frameIdx = frameid - beginFrameNumber;
     if (frameIdx >= 0 && frameIdx < m_frames.size()) {
         log_debug("dumping frame {}", frameid);
-        toDisk(cacheFramePath, frameid, m_frames[frameIdx].view_objects);
+        toDisk(cacheFramePath, frameid, m_frames[frameIdx].view_objects, "", true);
     }
 }
 
@@ -243,7 +412,7 @@ GlobalComm::ViewObjects const* GlobalComm::_getViewObjects(const int frameid) {
     if (maxCachedFrames != 0) {
         // load back one gc:
         if (!m_inCacheFrames.count(frameid)) {  // notinmem then cacheit
-            bool ret = fromDisk(cacheFramePath, frameid, m_frames[frameIdx].view_objects);
+            bool ret = fromDiskByObjsManager(cacheFramePath, frameid, m_frames[frameIdx].view_objects, toViewNodesId);
             if (!ret)
                 return nullptr;
 
@@ -381,6 +550,12 @@ ZENO_API void GlobalComm::removeCachePath()
         std::filesystem::remove_all(dirToRemove);
         zeno::log_info("remove dir: {}", dirToRemove);
     }
+}
+
+ZENO_API void GlobalComm::setToViewNodes(std::vector<std::string>&nodes)
+{
+    std::lock_guard lck(m_mtx);
+    toViewNodesId = std::move(nodes);
 }
 
 }

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -412,6 +412,7 @@ GlobalComm::ViewObjects const* GlobalComm::_getViewObjects(const int frameid) {
     if (maxCachedFrames != 0) {
         // load back one gc:
         if (!m_inCacheFrames.count(frameid)) {  // notinmem then cacheit
+            auto x = &m_inCacheFrames;
             bool ret = fromDiskByObjsManager(cacheFramePath, frameid, m_frames[frameIdx].view_objects, toViewNodesId);
             if (!ret)
                 return nullptr;
@@ -463,11 +464,11 @@ ZENO_API bool GlobalComm::load_objects(
     auto const* viewObjs = _getViewObjects(frameid);
     if (viewObjs) {
         zeno::log_trace("load_objects: {} objects at frame {}", viewObjs->size(), frameid);
-        inserted = callback(viewObjs->m_curr);
+        inserted = objectsMan->load_objects(viewObjs->m_curr);
     }
     else {
         zeno::log_trace("load_objects: no objects at frame {}", frameid);
-        inserted = callback({});
+        inserted = objectsMan->load_objects({});
     }
     return inserted;
 }

--- a/zeno/src/extra/ObjectsManager.cpp
+++ b/zeno/src/extra/ObjectsManager.cpp
@@ -1,7 +1,6 @@
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/types/UserData.h>
 #include <zeno/types/PrimitiveObject.h>
-#include <zenovis/bate/IGraphic.h>
 #include <zeno/core/IObject.h>
 #include <zeno/utils/log.h>
 #include <zeno/types/MaterialObject.h>
@@ -13,7 +12,7 @@ std::set<std::string> lightCameraNodes({
     });
 std::string matlNode = "ShaderFinalize";
 
-namespace zenovis {
+namespace zeno {
 
 ObjectsManager::ObjectsManager() = default;
 ObjectsManager::~ObjectsManager() = default;
@@ -47,11 +46,11 @@ bool ObjectsManager::load_objects(std::map<std::string, std::shared_ptr<zeno::IO
     return inserted;
 }
 
-void ObjectsManager::clear_objects() {
+ZENO_API void ObjectsManager::clear_objects() {
     objects.clear();
 }
 
-std::optional<zeno::IObject* > ObjectsManager::get(std::string nid) {
+ZENO_API std::optional<zeno::IObject* > ObjectsManager::get(std::string nid) {
     for (auto &[key, ptr]: this->pairs()) {
         if (key != nid) {
             continue;

--- a/zeno/src/funcs/ObjectCodecList.cpp
+++ b/zeno/src/funcs/ObjectCodecList.cpp
@@ -49,7 +49,9 @@ bool encodeListObject(ListObject const *obj, std::back_insert_iterator<std::vect
         tab[i * 2 + 1] = len;
         base += len;
     }
-    std::copy_n(tab.data(), tab.size() * sizeof(size_t), it);
+    for (size_t i : tab)
+        std::copy_n((char const*)&i, sizeof(i), it);
+    //std::copy_n(tab.data(), tab.size() * sizeof(size_t), it); //can't copy data correctly?
     std::copy(fin.begin(), fin.end(), it);
 
     return true;

--- a/zenovis/include/zenovis/ObjectsManager.h
+++ b/zenovis/include/zenovis/ObjectsManager.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <set>
 
 namespace zenovis {
 
@@ -34,6 +35,18 @@ struct ObjectsManager : zeno::disable_copy {
     bool load_objects(std::map<std::string, std::shared_ptr<zeno::IObject>> const &objs);
 
     std::optional<zeno::IObject*> get(std::string nid);
+
+    //---determine update type accord to objs changes---
+    enum RenderType
+    {
+        UNDEFINED = 0,
+        UPDATE_ALL,
+        UPDATE_LIGHT_CAMERA,
+        UPDATE_MATERIAL
+    };
+    void determineRenderType(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);
+    RenderType renderType = UNDEFINED;
+    std::map<std::string, int> lastToViewNodesType;
 };
 
 }

--- a/zenovis/include/zenovis/Scene.h
+++ b/zenovis/include/zenovis/Scene.h
@@ -16,7 +16,7 @@ struct Camera;
 struct DrawOptions;
 struct ShaderManager;
 struct GraphicsManager;
-struct ObjectsManager;
+//struct ObjectsManager;
 struct RenderManager;
 
 enum class PICK_MODE {
@@ -35,7 +35,7 @@ struct Scene : zeno::disable_copy {
     std::unique_ptr<Camera> camera;
     std::unique_ptr<DrawOptions> drawOptions;
     std::unique_ptr<ShaderManager> shaderMan;
-    std::unique_ptr<ObjectsManager> objectsMan;
+    //std::unique_ptr<ObjectsManager> objectsMan;
     std::unique_ptr<RenderManager> renderMan;
 
     Scene();

--- a/zenovis/src/bate/FrameBufferPicker.cpp
+++ b/zenovis/src/bate/FrameBufferPicker.cpp
@@ -3,7 +3,9 @@
 #include <zenovis/Scene.h>
 #include <zenovis/bate/IGraphic.h>
 #include <zenovis/ShaderManager.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 #include <zenovis/opengl/buffer.h>
 #include <zenovis/opengl/shader.h>
 #include <zenovis/opengl/texture.h>
@@ -285,7 +287,7 @@ struct FrameBufferPicker : IPicker {
         // construct prim set
         // use focus_prim if focus_prim_name is not empty else all prims
         vector<std::pair<string, std::shared_ptr<zeno::IObject>>> prims;
-        auto prims_shared = scene->objectsMan->pairsShared();
+        auto prims_shared = zeno::getSession().globalComm->objectsMan->pairsShared();
         if (!focus_prim_name.empty()) {
             std::shared_ptr<zeno::IObject> focus_prim;
             for (const auto& [k, v] : prims_shared) {

--- a/zenovis/src/bate/HudGraphicPrimHighlight.cpp
+++ b/zenovis/src/bate/HudGraphicPrimHighlight.cpp
@@ -75,120 +75,130 @@ struct PrimitiveHighlight : IGraphicDraw {
 
     virtual void draw() override {
         if (scene->select_mode == PICK_MODE::PICK_OBJECT) {
-            for (const auto &prim_id : scene->selected) {
+            const auto& cb = [&]() {
+                for (const auto& prim_id : scene->selected) {
+                    // ----- get primitive -----
+                    PrimitiveObject* prim = nullptr;
+                    auto optional_prim = zeno::getSession().globalComm->get(prim_id);
+                    if (optional_prim.has_value())
+                        prim = dynamic_cast<PrimitiveObject*>(zeno::getSession().globalComm->get(prim_id).value());
+                    else {
+                        auto node_id = prim_id.substr(0, prim_id.find_first_of(':'));
+                        for (const auto& [n, p] : zeno::getSession().globalComm->pairsShared()) {
+                            if (n.find(node_id) != std::string::npos) {
+                                prim = dynamic_cast<PrimitiveObject*>(p.get());
+                                break;
+                            }
+                        }
+                    }
+                    if (!prim) continue;
+                    // ----- draw selected particles -----
+                    if (prim->tris->empty()) {
+                        // prepare data
+                        auto const& verts = prim->verts;
+
+                        // bind buffers
+                        vbo->bind_data(verts.data(), verts.size() * sizeof(verts[0]));
+                        vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 3, GL_FLOAT, 3);
+
+                        // draw particles
+                        CHECK_GL(glEnable(GL_PROGRAM_POINT_SIZE));
+                        shader->use();
+                        scene->camera->set_program_uniforms(shader);
+                        CHECK_GL(glDrawArrays(GL_POINTS, 0, verts.size()));
+                        CHECK_GL(glDisable(GL_PROGRAM_POINT_SIZE));
+
+                        // unbind buffers
+                        vbo->disable_attribute(0);
+                        vbo->unbind();
+                    }
+                    else
+                        continue;
+                }
+            };
+            zeno::getSession().globalComm->mutexCallback(cb);
+        }
+
+        bool isnull = false;
+        const auto& cb = [&]() {
+            for (const auto& [prim_id, elements] : scene->selected_elements) {
                 // ----- get primitive -----
-                PrimitiveObject *prim = nullptr;
-                auto optional_prim = zeno::getSession().globalComm->objectsMan->get(prim_id);
+                PrimitiveObject* prim = nullptr;
+                auto optional_prim = zeno::getSession().globalComm->get(prim_id);
                 if (optional_prim.has_value())
-                    prim = dynamic_cast<PrimitiveObject *>(zeno::getSession().globalComm->objectsMan->get(prim_id).value());
+                    prim = dynamic_cast<PrimitiveObject*>(zeno::getSession().globalComm->get(prim_id).value());
                 else {
                     auto node_id = prim_id.substr(0, prim_id.find_first_of(':'));
-                    for (const auto &[n, p] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
+                    for (const auto& [n, p] : zeno::getSession().globalComm->pairsShared()) {
                         if (n.find(node_id) != std::string::npos) {
-                            prim = dynamic_cast<PrimitiveObject *>(p.get());
+                            prim = dynamic_cast<PrimitiveObject*>(p.get());
                             break;
                         }
                     }
                 }
-                if (!prim) continue;
-                // ----- draw selected particles -----
-                if (prim->tris->empty()) {
-                    // prepare data
-                    auto const &verts = prim->verts;
+                if (prim == nullptr) {
+                    isnull = true;
+                    return;
+                }
+                auto selected_count = elements.size();
+                // ----- prepare data -----
+                auto const& pos = prim->attr<zeno::vec3f>("pos");
 
-                    // bind buffers
-                    vbo->bind_data(verts.data(), verts.size() * sizeof(verts[0]));
-                    vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 3, GL_FLOAT, 3);
+                // ----- bind buffers -----
+                vbo->bind_data(pos.data(), pos.size() * sizeof(pos[0]));
+                vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 3, GL_FLOAT, 3);
 
-                    // draw particles
+                // ----- draw selected vertices -----
+                if (scene->select_mode == PICK_MODE::PICK_VERTEX) {
+                    // prepare indices
                     CHECK_GL(glEnable(GL_PROGRAM_POINT_SIZE));
+                    vector<int> ind(selected_count);
+                    int i = 0;
+                    for (const auto& idx : elements)
+                        ind[i++] = idx;
+                    // draw points
                     shader->use();
                     scene->camera->set_program_uniforms(shader);
-                    CHECK_GL(glDrawArrays(GL_POINTS, 0, verts.size()));
+                    ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
+                    CHECK_GL(glDrawElements(GL_POINTS, selected_count, GL_UNSIGNED_INT, 0));
                     CHECK_GL(glDisable(GL_PROGRAM_POINT_SIZE));
+                }
 
-                    // unbind buffers
-                    vbo->disable_attribute(0);
-                    vbo->unbind();
-                } else
-                    continue;
-            }
-        }
+                // ----- draw selected edges -----
+                if (scene->select_mode == PICK_MODE::PICK_LINE) {
+                    if (prim->lines->empty()) return;
+                    // prepare indices
+                    vector<vec2i> ind(selected_count);
+                    int i = 0;
+                    for (const auto& idx : elements)
+                        ind[i++] = prim->lines[idx];
+                    // draw lines
+                    shader->use();
+                    scene->camera->set_program_uniforms(shader);
+                    ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
+                    CHECK_GL(glDrawElements(GL_LINES, selected_count * 2, GL_UNSIGNED_INT, 0));
+                    ebo->unbind();
+                }
 
-        for (const auto& [prim_id, elements] : scene->selected_elements) {
-            // ----- get primitive -----
-            PrimitiveObject* prim = nullptr;
-            auto optional_prim = zeno::getSession().globalComm->objectsMan->get(prim_id);
-            if (optional_prim.has_value())
-                prim = dynamic_cast<PrimitiveObject*>(zeno::getSession().globalComm->objectsMan->get(prim_id).value());
-            else {
-                auto node_id = prim_id.substr(0, prim_id.find_first_of(':'));
-                for (const auto& [n, p] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
-                    if (n.find(node_id) != std::string::npos) {
-                        prim = dynamic_cast<PrimitiveObject*>(p.get());
-                        break;
-                    }
+                // ----- draw selected meshes -----
+                if (scene->select_mode == PICK_MODE::PICK_MESH) {
+                    // prepare indices
+                    vector<vec3i> ind(selected_count);
+                    int i = 0;
+                    for (const auto& idx : elements)
+                        ind[i++] = prim->tris[idx];
+                    // draw meshes
+                    shader->use();
+                    scene->camera->set_program_uniforms(shader);
+                    ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
+                    CHECK_GL(glDrawElements(GL_TRIANGLES, selected_count * 3, GL_UNSIGNED_INT, 0));
+                    ebo->unbind();
                 }
             }
-            if (prim == nullptr) {
-                return;
-            }
-            auto selected_count = elements.size();
-            // ----- prepare data -----
-            auto const &pos = prim->attr<zeno::vec3f>("pos");
-
-            // ----- bind buffers -----
-            vbo->bind_data(pos.data(), pos.size() * sizeof(pos[0]));
-            vbo->attribute(0, sizeof(float) * 0, sizeof(float) * 3, GL_FLOAT, 3);
-
-            // ----- draw selected vertices -----
-            if (scene->select_mode == PICK_MODE::PICK_VERTEX) {
-                // prepare indices
-                CHECK_GL(glEnable(GL_PROGRAM_POINT_SIZE));
-                vector<int> ind(selected_count);
-                int i = 0;
-                for (const auto& idx : elements)
-                    ind[i++] = idx;
-                // draw points
-                shader->use();
-                scene->camera->set_program_uniforms(shader);
-                ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
-                CHECK_GL(glDrawElements(GL_POINTS, selected_count, GL_UNSIGNED_INT, 0));
-                CHECK_GL(glDisable(GL_PROGRAM_POINT_SIZE));
-            }
-
-            // ----- draw selected edges -----
-            if (scene->select_mode == PICK_MODE::PICK_LINE) {
-                if (prim->lines->empty()) return;
-                // prepare indices
-                vector<vec2i> ind(selected_count);
-                int i = 0;
-                for (const auto& idx : elements)
-                    ind[i++] = prim->lines[idx];
-                // draw lines
-                shader->use();
-                scene->camera->set_program_uniforms(shader);
-                ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
-                CHECK_GL(glDrawElements(GL_LINES, selected_count * 2, GL_UNSIGNED_INT, 0));
-                ebo->unbind();
-            }
-
-            // ----- draw selected meshes -----
-            if (scene->select_mode == PICK_MODE::PICK_MESH) {
-                // prepare indices
-                vector<vec3i> ind(selected_count);
-                int i = 0;
-                for (const auto& idx : elements)
-                    ind[i++] = prim->tris[idx];
-                // draw meshes
-                shader->use();
-                scene->camera->set_program_uniforms(shader);
-                ebo->bind_data(ind.data(), selected_count * sizeof(ind[0]));
-                CHECK_GL(glDrawElements(GL_TRIANGLES, selected_count * 3, GL_UNSIGNED_INT, 0));
-                ebo->unbind();
-            }
-        }
-
+        };
+        zeno::getSession().globalComm->mutexCallback(cb);
+        if (isnull)
+            return;
         vbo->disable_attribute(0);
         vbo->unbind();
     }

--- a/zenovis/src/bate/HudGraphicPrimHighlight.cpp
+++ b/zenovis/src/bate/HudGraphicPrimHighlight.cpp
@@ -3,7 +3,9 @@
 #include <zenovis/Scene.h>
 #include <zenovis/bate/IGraphic.h>
 #include <zenovis/ShaderManager.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 #include <zenovis/opengl/buffer.h>
 #include <zenovis/opengl/shader.h>
 #include <zenovis/opengl/vao.h>
@@ -76,12 +78,12 @@ struct PrimitiveHighlight : IGraphicDraw {
             for (const auto &prim_id : scene->selected) {
                 // ----- get primitive -----
                 PrimitiveObject *prim = nullptr;
-                auto optional_prim = scene->objectsMan->get(prim_id);
+                auto optional_prim = zeno::getSession().globalComm->objectsMan->get(prim_id);
                 if (optional_prim.has_value())
-                    prim = dynamic_cast<PrimitiveObject *>(scene->objectsMan->get(prim_id).value());
+                    prim = dynamic_cast<PrimitiveObject *>(zeno::getSession().globalComm->objectsMan->get(prim_id).value());
                 else {
                     auto node_id = prim_id.substr(0, prim_id.find_first_of(':'));
-                    for (const auto &[n, p] : scene->objectsMan->pairsShared()) {
+                    for (const auto &[n, p] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
                         if (n.find(node_id) != std::string::npos) {
                             prim = dynamic_cast<PrimitiveObject *>(p.get());
                             break;
@@ -116,12 +118,12 @@ struct PrimitiveHighlight : IGraphicDraw {
         for (const auto& [prim_id, elements] : scene->selected_elements) {
             // ----- get primitive -----
             PrimitiveObject* prim = nullptr;
-            auto optional_prim = scene->objectsMan->get(prim_id);
+            auto optional_prim = zeno::getSession().globalComm->objectsMan->get(prim_id);
             if (optional_prim.has_value())
-                prim = dynamic_cast<PrimitiveObject*>(scene->objectsMan->get(prim_id).value());
+                prim = dynamic_cast<PrimitiveObject*>(zeno::getSession().globalComm->objectsMan->get(prim_id).value());
             else {
                 auto node_id = prim_id.substr(0, prim_id.find_first_of(':'));
-                for (const auto& [n, p] : scene->objectsMan->pairsShared()) {
+                for (const auto& [n, p] : zeno::getSession().globalComm->objectsMan->pairsShared()) {
                     if (n.find(node_id) != std::string::npos) {
                         prim = dynamic_cast<PrimitiveObject*>(p.get());
                         break;

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -38,7 +38,10 @@ struct RenderEngineBate : RenderEngine {
     }
 
     void update() override {
-        graphicsMan->load_objects(scene->objectsMan->pairsShared());
+        if (graphicsMan->load_objects(scene->objectsMan->pairsShared()))
+        {
+            scene->objectsMan->renderType = ObjectsManager::UNDEFINED;
+        }
     }
 
     void draw() override {

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -1,7 +1,9 @@
 #include <zenovis/RenderEngine.h>
 #include <zenovis/DrawOptions.h>
 #include <zenovis/bate/GraphicsManager.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 #include <zenovis/DrawOptions.h>
 #include <zenovis/bate/IGraphic.h>
 #include <zenovis/opengl/vao.h>
@@ -38,9 +40,9 @@ struct RenderEngineBate : RenderEngine {
     }
 
     void update() override {
-        if (graphicsMan->load_objects(scene->objectsMan->pairsShared()))
+        if (graphicsMan->load_objects(zeno::getSession().globalComm->objectsMan->pairsShared()))
         {
-            scene->objectsMan->renderType = ObjectsManager::UNDEFINED;
+            zeno::getSession().globalComm->objectsMan->renderType = zeno::ObjectsManager::UNDEFINED;
         }
     }
 

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -41,8 +41,7 @@ struct RenderEngineBate : RenderEngine {
 
     void update() override {
         const auto& cb = [&]() {
-            if (graphicsMan->load_objects(zeno::getSession().globalComm->pairsShared()))
-                zeno::getSession().globalComm->setRenderType(zeno::GlobalComm::UNDEFINED);
+            graphicsMan->load_objects(zeno::getSession().globalComm->pairsShared());
         };
         zeno::getSession().globalComm->mutexCallback(cb);
     }

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -40,10 +40,11 @@ struct RenderEngineBate : RenderEngine {
     }
 
     void update() override {
-        if (graphicsMan->load_objects(zeno::getSession().globalComm->objectsMan->pairsShared()))
-        {
-            zeno::getSession().globalComm->objectsMan->renderType = zeno::ObjectsManager::UNDEFINED;
-        }
+        const auto& cb = [&]() {
+            if (graphicsMan->load_objects(zeno::getSession().globalComm->pairsShared()))
+                zeno::getSession().globalComm->setRenderType(zeno::GlobalComm::UNDEFINED);
+        };
+        zeno::getSession().globalComm->mutexCallback(cb);
     }
 
     void draw() override {

--- a/zenovis/src/optx/RenderEngineOptx.cpp
+++ b/zenovis/src/optx/RenderEngineOptx.cpp
@@ -844,16 +844,19 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
         if (graphicsMan->load_objects(scene->objectsMan->pairs()))
         {
             meshNeedUpdate = matNeedUpdate = true;
-            if (scene->drawOptions->updateMatlOnly)
+            if (scene->objectsMan->renderType == ObjectsManager::UPDATE_MATERIAL)
             {
+                scene->drawOptions->updateMatlOnly = true;
                 lightNeedUpdate = meshNeedUpdate = false;
                 matNeedUpdate = true;
             }
-            if (scene->drawOptions->updateLightCameraOnly)
+            if (scene->objectsMan->renderType == ObjectsManager::UPDATE_LIGHT_CAMERA)
             {
+                scene->drawOptions->updateLightCameraOnly = true;
                 lightNeedUpdate = true;
                 matNeedUpdate = meshNeedUpdate = false;
             }
+            scene->objectsMan->renderType = ObjectsManager::UNDEFINED;
         }
         graphicsMan->load_shader_uniforms(scene->objectsMan->pairs());
     }

--- a/zenovis/src/optx/RenderEngineOptx.cpp
+++ b/zenovis/src/optx/RenderEngineOptx.cpp
@@ -15,7 +15,7 @@
 #include <zeno/types/TextureObject.h>
 #include <zeno/types/CameraObject.h>
 #include <zeno/types/MatrixObject.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zeno/utils/UserData.h>
 #include <zeno/extra/TempNode.h>
 #include <zeno/utils/fileio.h>
@@ -32,6 +32,8 @@
 #include "../../xinxinoptix/OptiXStuff.h"
 #include <zeno/types/PrimitiveTools.h>
 #include <zeno/types/StringObject.h>
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 #include <map>
 #include <string>
@@ -829,36 +831,36 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
 
     void update() override {
 
-        if(graphicsMan->need_update_light(scene->objectsMan->pairs())
-            || scene->objectsMan->needUpdateLight)
+        if(graphicsMan->need_update_light(zeno::getSession().globalComm->objectsMan->pairs())
+            || zeno::getSession().globalComm->objectsMan->needUpdateLight)
         {
-            graphicsMan->load_light_objects(scene->objectsMan->lightObjects);
+            graphicsMan->load_light_objects(zeno::getSession().globalComm->objectsMan->lightObjects);
             lightNeedUpdate = true;
-            scene->objectsMan->needUpdateLight = false;
+            zeno::getSession().globalComm->objectsMan->needUpdateLight = false;
             scene->drawOptions->needRefresh = true;
         }
 
-        if (graphicsMan->load_static_objects(scene->objectsMan->pairs())) {
+        if (graphicsMan->load_static_objects(zeno::getSession().globalComm->objectsMan->pairs())) {
             staticNeedUpdate = true;
         }
-        if (graphicsMan->load_objects(scene->objectsMan->pairs()))
+        if (graphicsMan->load_objects(zeno::getSession().globalComm->objectsMan->pairs()))
         {
             meshNeedUpdate = matNeedUpdate = true;
-            if (scene->objectsMan->renderType == ObjectsManager::UPDATE_MATERIAL)
+            if (zeno::getSession().globalComm->objectsMan->renderType == zeno::ObjectsManager::UPDATE_MATERIAL)
             {
                 scene->drawOptions->updateMatlOnly = true;
                 lightNeedUpdate = meshNeedUpdate = false;
                 matNeedUpdate = true;
             }
-            if (scene->objectsMan->renderType == ObjectsManager::UPDATE_LIGHT_CAMERA)
+            if (zeno::getSession().globalComm->objectsMan->renderType == zeno::ObjectsManager::UPDATE_LIGHT_CAMERA)
             {
                 scene->drawOptions->updateLightCameraOnly = true;
                 lightNeedUpdate = true;
                 matNeedUpdate = meshNeedUpdate = false;
             }
-            scene->objectsMan->renderType = ObjectsManager::UNDEFINED;
+            zeno::getSession().globalComm->objectsMan->renderType = zeno::ObjectsManager::UNDEFINED;
         }
-        graphicsMan->load_shader_uniforms(scene->objectsMan->pairs());
+        graphicsMan->load_shader_uniforms(zeno::getSession().globalComm->objectsMan->pairs());
     }
 
 #define MY_CAM_ID(cam) cam.m_nx, cam.m_ny, cam.m_lodup, cam.m_lodfront, cam.m_lodcenter, cam.m_fov, cam.focalPlaneDistance, cam.m_aperture

--- a/zenovis/src/optx/RenderEngineOptx.cpp
+++ b/zenovis/src/optx/RenderEngineOptx.cpp
@@ -846,13 +846,13 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
             if (graphicsMan->load_objects(zeno::getSession().globalComm->pairs()))
             {
                 meshNeedUpdate = matNeedUpdate = true;
-                if (zeno::getSession().globalComm->getRenderType() == zeno::GlobalComm::UPDATE_MATERIAL)
+                if (zeno::getSession().globalComm->getRenderType() == zeno::GlobalComm::MATERIAL)
                 {
                     scene->drawOptions->updateMatlOnly = true;
                     lightNeedUpdate = meshNeedUpdate = false;
                     matNeedUpdate = true;
                 }
-                if (zeno::getSession().globalComm->getRenderType() == zeno::GlobalComm::UPDATE_LIGHT_CAMERA)
+                if (zeno::getSession().globalComm->getRenderType() == zeno::GlobalComm::LIGHT_CAMERA)
                 {
                     scene->drawOptions->updateLightCameraOnly = true;
                     lightNeedUpdate = true;

--- a/zenovis/src/zhxx/RenderEngineZhxx.cpp
+++ b/zenovis/src/zhxx/RenderEngineZhxx.cpp
@@ -79,8 +79,11 @@ struct RenderEngineZhxx : RenderEngine, zeno::disable_copy {
     }
 
     void update() override {
-        if (graphicsMan->load_objects(zeno::getSession().globalComm->objectsMan->pairsShared()))
-            giNeedUpdate = true;
+        const auto& cb = [&]() {
+            if (graphicsMan->load_objects(zeno::getSession().globalComm->pairsShared()))
+                giNeedUpdate = true;
+        };
+        zeno::getSession().globalComm->mutexCallback(cb);
     }
 
     void draw() override {

--- a/zenovis/src/zhxx/RenderEngineZhxx.cpp
+++ b/zenovis/src/zhxx/RenderEngineZhxx.cpp
@@ -2,11 +2,13 @@
 #include <zenovis/RenderEngine.h>
 #include <zenovis/DrawOptions.h>
 #include <zenovis/bate/GraphicsManager.h>
-#include <zenovis/ObjectsManager.h>
+#include <zeno/extra/ObjectsManager.h>
 #include <zenovis/bate/IGraphic.h>
 #include <zenovis/opengl/vao.h>
 #include <zenovis/opengl/scope.h>
 #include "../../zhxxvis/zenvisapi.hpp"
+#include <zeno/core/Session.h>
+#include <zeno/extra/GlobalComm.h>
 
 namespace zenovis::zhxx {
 
@@ -77,7 +79,7 @@ struct RenderEngineZhxx : RenderEngine, zeno::disable_copy {
     }
 
     void update() override {
-        if (graphicsMan->load_objects(scene->objectsMan->pairsShared()))
+        if (graphicsMan->load_objects(zeno::getSession().globalComm->objectsMan->pairsShared()))
             giNeedUpdate = true;
     }
 


### PR DESCRIPTION
1. 每个toview输出的obj存为一个cache
2. 计算时仅计算dirty的toview节点
3. 渲染时根据变化的（删除/修改/增加）的toview节点决定渲染全部或仅渲染灯光/材质
4. 仅在切换cache模式（采用临时cache目录/指定cache目录），更改cacheroot，打开新文件或上一次运行目录不存在，可用帧不完整，重新运行录制，五种情况下新建cache目录，否则沿用上一次运行的cache目录