### PR TITLE
Isolate cache objs

### DIFF
--- a/ui/zenoedit/acceptor/transferacceptor.cpp
+++ b/ui/zenoedit/acceptor/transferacceptor.cpp
@@ -525,6 +525,10 @@ void TransferAcceptor::setOptions(const QString& id, const QStringList& options)
         {
             opts |= OPT_MUTE;
         }
+        else if (optName == "CACHE")
+        {
+            opts |= OPT_CACHE;
+        }
         else if (optName == "collapsed")
         {
             data[ROLE_COLLASPED] = true;

--- a/ui/zenoedit/viewportinteraction/nodesync.cpp
+++ b/ui/zenoedit/viewportinteraction/nodesync.cpp
@@ -71,8 +71,7 @@ bool NodeSyncMgr::checkNodeInputHasValue(const QModelIndex& node,
     return inSocket.info.links.isEmpty();
 }
 
-std::optional<NodeLocation> NodeSyncMgr::checkNodeLinkedSpecificNode(const QModelIndex& node,
-                                                                     const std::string& node_type) {
+std::optional<NodeLocation> NodeSyncMgr::checkNodeLinkedSpecificNode(const QModelIndex& node, const std::string& node_type, bool SpecificNodeShouldBeView) {
     auto graph_model = zenoApp->graphsManagment()->currentModel();
     if (!graph_model) {
         return {};
@@ -96,9 +95,13 @@ std::optional<NodeLocation> NodeSyncMgr::checkNodeLinkedSpecificNode(const QMode
             auto linked_node = search_result[0].targetIdx;
             auto linked_subgraph = search_result[0].subgIdx;
             auto option = linked_node.data(ROLE_OPTIONS).toInt();
-            if (option & OPT_VIEW)
-                return NodeLocation(linked_node,
-                                    linked_subgraph);
+            if (SpecificNodeShouldBeView) {
+                if (option & OPT_VIEW)
+                    return NodeLocation(linked_node, linked_subgraph);
+            }
+            else {
+                return NodeLocation(linked_node, linked_subgraph);
+            }
         }
     }
     return {};

--- a/ui/zenoedit/viewportinteraction/nodesync.h
+++ b/ui/zenoedit/viewportinteraction/nodesync.h
@@ -45,7 +45,8 @@ class NodeSyncMgr {
     bool checkNodeInputHasValue(const QModelIndex& node,
                                 const std::string& input_name);
     std::optional<NodeLocation> checkNodeLinkedSpecificNode(const QModelIndex& node,       // check which node's output?
-                                                            const std::string& node_type); // check node output linked which node type
+                                                            const std::string& node_type,   // check node output linked which node type
+                                                            bool SpecificNodeShouldView);   // the linked node must be view
     // get input or output
     std::vector<NodeLocation> getInputNodes(const QModelIndex& node,
                                             const std::string& input_name);
@@ -141,6 +142,7 @@ class NodeSyncMgr {
     void registerDefaultSocketName() {
         m_prim_sock_map["BindMaterial"] = "object";
         m_prim_sock_map["TransformPrimitive"] = "outPrim";
+        m_prim_sock_map["PrimitiveTransform"] = "outPrim";
         m_prim_sock_map["MakeList"] = "list";
     }
 };

--- a/ui/zenoedit/viewportinteraction/transform.cpp
+++ b/ui/zenoedit/viewportinteraction/transform.cpp
@@ -11,7 +11,6 @@
 #include <glm/gtx/quaternion.hpp>
 #include <zeno/core/Session.h>
 #include <zeno/extra/GlobalComm.h>
-#include <regex>
 
 namespace zeno {
 
@@ -378,7 +377,7 @@ void FakeTransformer::createNewTransformNode(NodeLocation& node_location,
                                  "quatRotation",
                                  rotate);
 
-    if (user_data.has("object-id"))
+    if (user_data.has("list-index"))
     {
         if (listitemGroupPath == "")
         {

--- a/ui/zenoedit/viewportinteraction/transform.h
+++ b/ui/zenoedit/viewportinteraction/transform.h
@@ -61,7 +61,7 @@ private:
     void rotate(glm::vec3 start_vec, glm::vec3 end_vec, glm::vec3 axis);
 
     void createNewTransformNode(NodeLocation& node_location,
-                                const std::string& obj_name);
+                                const std::string& obj_name, const std::string listitemGroupPath = "");
     void syncToTransformNode(NodeLocation& node_location,
                              const std::string& obj_name);
 

--- a/ui/zenoio/writer/zsgwriter.cpp
+++ b/ui/zenoio/writer/zsgwriter.cpp
@@ -399,6 +399,9 @@ void ZsgWriter::dumpNode(const NODE_DATA& data, RAPIDJSON_WRITER& writer)
         if (opts & OPT_VIEW) {
             options.push_back("VIEW");
         }
+        if (opts & OPT_CACHE) {
+            options.push_back("CACHE");
+        }
         if (data[ROLE_COLLASPED].toBool())
         {
             options.push_back("collapsed");

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -124,6 +124,7 @@ private:
     ViewObjects const* _getViewObjects(const int frameid, bool& inserted);
     void _initStaticObjects();
     std::map<std::string, bool> toViewNodesId;
+    static std::map<std::string, std::string> lastListitemToViewNodesId;
 
     //-----ObjectsManager-----
     MapObjects m_transferObjs;

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -124,7 +124,7 @@ private:
     ViewObjects const* _getViewObjects(const int frameid, bool& inserted);
     void _initStaticObjects();
     std::map<std::string, bool> toViewNodesId;
-    static std::map<std::string, std::string> lastListitemToViewNodesId;
+    static std::map<std::string, std::string> lastListitemToViewNodesId;    //listitem belongs to which toviewnode
     static int lastLoadedFrameID;
 
     //-----ObjectsManager-----

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -125,6 +125,7 @@ private:
     void _initStaticObjects();
     std::map<std::string, bool> toViewNodesId;
     static std::map<std::string, std::string> lastListitemToViewNodesId;
+    static int lastLoadedFrameID;
 
     //-----ObjectsManager-----
     MapObjects m_transferObjs;

--- a/zeno/src/core/INode.cpp
+++ b/zeno/src/core/INode.cpp
@@ -76,6 +76,8 @@ ZENO_API bool zeno::INode::getTmpCache()
 {
     GlobalComm::ViewObjects objs;
     int frameid = zeno::getSession().globalState->frameid;
+    if (m_status & NodeStatus::Once)
+        frameid = -1;
     bool ret = GlobalComm::fromDiskByRunner(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, myname);
     if (ret && objs.size() > 0)
     {
@@ -113,22 +115,11 @@ ZENO_API void zeno::INode::writeTmpCaches()
     bool bStatic = (Once & m_status);
     int frameid = bStatic ? -1 : zeno::getSession().globalState->frameid;
 
-    {   //store cache version
-        auto key = myname;
-        key.push_back(':');
-        if (bStatic)
-            key.append("static");
-        else
-            key.append(std::to_string(getThisSession()->globalState->frameid));
-        //key.push_back(':');
-        //key.append(std::to_string(getThisSession()->globalState->sessionid));
-        //just register obj keys.
-        if (bStatic) {
-            getThisSession()->globalComm->addStaticObject(key, std::make_shared<IObject>());
-        }
-        else {
-            getThisSession()->globalComm->addViewObject(key, std::make_shared<IObject>());
-        }
+    if (bStatic) {
+        getThisSession()->globalComm->addStaticObject(myname, std::make_shared<IObject>());
+    }
+    else {
+        getThisSession()->globalComm->addViewObject(myname, std::make_shared<IObject>());
     }
     GlobalComm::toDisk(zeno::getSession().globalComm->objTmpCachePath, frameid, objs, myname, false);
 }

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -426,7 +426,11 @@ bool GlobalComm::fromDiskByRunner(std::string cachedir, int frameid, GlobalComm:
     if (cachedir.empty())
         return false;
     objs.clear();
-    auto dir = std::filesystem::u8path(cachedir) / std::to_string(1000000 + frameid).substr(1);
+    std::filesystem::path dir;
+    if (frameid == -1)
+        dir = std::filesystem::u8path(cachedir + "/_static");
+    else
+        dir = std::filesystem::u8path(cachedir) / std::to_string(1000000 + frameid).substr(1);
     if (!std::filesystem::exists(dir))
         return false;
 


### PR DESCRIPTION
在apply makelist时生成每个对象的索引，primitivetransform可以拖动多个对象
修复以下存在问题的情况
1. 计算进程加载once对象cache
2. cache加载上限大于1
3. list为once时加载list的cache
4. 复制节点时没有复制OPT_CACHE