### PR TITLE
Isolate cache objs

### DIFF
--- a/ui/zenoedit/cache/zcachemgr.cpp
+++ b/ui/zenoedit/cache/zcachemgr.cpp
@@ -5,6 +5,7 @@
 #include <zenomodel/include/graphsmanagment.h>
 #include "zenoapplication.h"
 #include "zenomainwindow.h"
+#include <zeno/extra/GlobalStatus.h>
 
 
 ZCacheMgr::ZCacheMgr()
@@ -164,7 +165,7 @@ bool ZCacheMgr::nextRunSkipCreateDir(LAUNCH_PARAM& param)
             if (! QDir(last.path() + "/" + QString::number(1000000 + frame).right(6)).exists()) //incomplete cache
                 return false;
         auto& globalComm = zeno::getSession().globalComm;
-        if (globalComm->numOfFinishedFrame() < (param.endFrame - param.beginFrame + 1))
+        if (globalComm->numOfFinishedFrame() < (param.endFrame - param.beginFrame + 1) && !zeno::getSession().globalStatus->error)
             return false;
     }
     return true;

--- a/ui/zenoedit/launch/viewdecode.cpp
+++ b/ui/zenoedit/launch/viewdecode.cpp
@@ -162,6 +162,7 @@ struct PacketProc {
                 zenoApp->graphsManagment()->appendErr(QString::fromStdString(nodeName),
                                                       QString::fromStdString(stat->error->message));
             }
+            AppHelper::markLastDirtyNodesDirty(true);
 
         } else {
             zeno::log_warn("unknown packet action type {}", action);

--- a/ui/zenoedit/nodesview/zenographseditor.cpp
+++ b/ui/zenoedit/nodesview/zenographseditor.cpp
@@ -990,7 +990,7 @@ void ZenoGraphsEditor::onAction(QAction* pAction, const QVariantList& args, bool
         QVariant varCacheNum = inst.getValue("zencachenum");
         QVariant varAutoCleanCache = inst.getValue("zencache-autoclean");
 
-        bool bEnableCache = varEnableCache.isValid() ? varEnableCache.toBool() : false;
+        bool bEnableCache = true;
         bool bTempCacheDir = varTempCacheDir.isValid() ? varTempCacheDir.toBool() : false;
         QString cacheRootDir = varCacheRoot.isValid() ? varCacheRoot.toString() : "";
         int cacheNum = varCacheNum.isValid() ? varCacheNum.toInt() : 1;
@@ -1020,37 +1020,19 @@ void ZenoGraphsEditor::onAction(QAction* pAction, const QVariantList& args, bool
         pSpinBox->setValue(cacheNum);
         pSpinBox->setEnabled(bEnableCache);
 
-        QCheckBox *pCheckbox = new QCheckBox;
-        pCheckbox->setCheckState(bEnableCache ? Qt::Checked : Qt::Unchecked);
-        connect(pCheckbox, &QCheckBox::stateChanged, [=](bool state) {
-            if (!state)
-            {
-                pSpinBox->clear();
-                pathLineEdit->clear();
-                pTempCacheDir->setCheckState(Qt::Unchecked);
-                pAutoCleanCache->setCheckState(Qt::Unchecked);
-            }
-            pSpinBox->setEnabled(state);
-            pathLineEdit->setEnabled(state);
-            pTempCacheDir->setEnabled(state);
-            pAutoCleanCache->setEnabled(state && !pTempCacheDir->isChecked());
-        });
-
         QDialogButtonBox* pButtonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
         QDialog dlg(this);
         QGridLayout* pLayout = new QGridLayout;
-        pLayout->addWidget(new QLabel(tr("Enable cache")), 0, 0);
-        pLayout->addWidget(pCheckbox, 0, 1);
+        pLayout->addWidget(new QLabel(tr("Temp cache directory")), 0, 0);
+        pLayout->addWidget(pTempCacheDir, 0, 1);
         pLayout->addWidget(new QLabel(tr("Cache num")), 1, 0);
         pLayout->addWidget(pSpinBox, 1, 1);
-        pLayout->addWidget(new QLabel(tr("Temp cache directory")), 2, 0);
-        pLayout->addWidget(pTempCacheDir, 2, 1);
-        pLayout->addWidget(new QLabel(tr("Cache root")), 3, 0);
-        pLayout->addWidget(pathLineEdit, 3, 1);
-        pLayout->addWidget(new QLabel(tr("Cache auto clean up")), 4, 0);
-        pLayout->addWidget(pAutoCleanCache, 4, 1);
-        pLayout->addWidget(pButtonBox, 5, 1);
+        pLayout->addWidget(new QLabel(tr("Cache root")), 2, 0);
+        pLayout->addWidget(pathLineEdit, 2, 1);
+        pLayout->addWidget(new QLabel(tr("Cache auto clean up")), 3, 0);
+        pLayout->addWidget(pAutoCleanCache, 3, 1);
+        pLayout->addWidget(pButtonBox, 4, 1);
 
         connect(pButtonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
         connect(pButtonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
@@ -1058,7 +1040,7 @@ void ZenoGraphsEditor::onAction(QAction* pAction, const QVariantList& args, bool
         dlg.setLayout(pLayout);
         if (QDialog::Accepted == dlg.exec())
         {
-            inst.setValue("zencache-enable", pCheckbox->checkState() == Qt::Checked);
+            inst.setValue("zencache-enable", true);
             inst.setValue("zencache-autoremove", pTempCacheDir->checkState() == Qt::Checked);
             inst.setValue("zencachedir", pathLineEdit->text());
             inst.setValue("zencachenum", pSpinBox->value());

--- a/ui/zenoedit/util/apphelper.h
+++ b/ui/zenoedit/util/apphelper.h
@@ -35,6 +35,11 @@ public:
     static bool updateCurve(QVariant oldVal, QVariant& val);
     static void dumpTabsToZsg(QDockWidget* dockWidget, RAPIDJSON_WRITER& writer);
     static void markAllNodesInMainGraphDirty(bool markNodeStyle = true);
+    static void markLastDirtyNodesDirty(bool markNodeStyle = true);
+    static void storeLastDirtyNodes();
+
+private:
+    static QVector<QModelIndex> lastDirtyNodes;
 };
 
 

--- a/zeno/include/zeno/extra/GlobalComm.h
+++ b/zeno/include/zeno/extra/GlobalComm.h
@@ -117,8 +117,8 @@ struct GlobalComm {
     ZENO_API RenderType getRenderTypeByObjects(std::map<std::string, std::shared_ptr<zeno::IObject>>& objs);
     ZENO_API void setRenderType(RenderType type);
     ZENO_API RenderType getRenderType();
-    ZENO_API void setRenderTypeBeta(RenderType type);
-    ZENO_API RenderType getRenderTypeBeta();
+    ZENO_API void setRenderTypeBeta(int bateEnginIdx, RenderType type);
+    ZENO_API RenderType getRenderTypeBeta(int bateEnginIdx);
 
 private:
     ViewObjects const* _getViewObjects(const int frameid, bool& inserted);
@@ -133,7 +133,7 @@ private:
     bool needUpdateLight = true;
 
     RenderType renderType = UNDEFINED;
-    RenderType renderTypeBeta = UNDEFINED;
+    std::map<int, GlobalComm::RenderType> renderTypeBeta;
     std::map<std::string, int> lastToViewNodesType;
     //------new change------
     void prepareForOptix(std::map<std::string, std::shared_ptr<zeno::IObject>> const& objs);

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -73,7 +73,7 @@ void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjec
         std::copy(keys.begin(), keys.end(), oit);
     }
     else {
-        std::filesystem::path cachepath = dir / (key + ".zencache");
+        std::filesystem::path cachepath = dir / (std::filesystem::u8path(key).string() + ".zencache");
         std::vector<char> bufCaches;
         std::vector<size_t> poses;
         std::string keys;
@@ -210,7 +210,7 @@ bool GlobalComm::fromDiskByObjsManager(std::string cachedir, int frameid, Global
 
     for (auto& [nodeid, isOnce] : nodesToLoad)
     {
-        std::filesystem::path cachePath = dir / (nodeid + ".zencache");
+        std::filesystem::path cachePath = dir / (std::filesystem::u8path(nodeid).string() + ".zencache");
         if (isOnce)
         {
             if (m_static_objects.find(nodeid) != m_static_objects.end())
@@ -379,7 +379,7 @@ bool GlobalComm::fromDiskByObjsManagerStatic(std::string cachedir, GlobalComm::V
 
     for (auto& [nodeid, isOnce] : nodesToLoad)
     {
-        std::filesystem::path cachePath = dir / (nodeid + ".zencache");
+        std::filesystem::path cachePath = dir / (std::filesystem::u8path(nodeid).string() + ".zencache");
         if (!std::filesystem::is_directory(cachePath) && std::filesystem::exists(cachePath)) {
             auto szBuffer = std::filesystem::file_size(cachePath);
             if (szBuffer == 0)
@@ -454,7 +454,7 @@ bool GlobalComm::fromDiskByRunner(std::string cachedir, int frameid, GlobalComm:
     if (!std::filesystem::exists(dir))
         return false;
 
-    std::filesystem::path filePath = dir / (filename + ".zencache");
+    std::filesystem::path filePath = dir / (std::filesystem::u8path(filename).string() + ".zencache");
     if (!std::filesystem::is_directory(filePath) && std::filesystem::exists(filePath)) {
 
         auto szBuffer = std::filesystem::file_size(filePath);

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -832,7 +832,8 @@ void GlobalComm::prepareForOptix(std::map<std::string, std::shared_ptr<zeno::IOb
 
 void GlobalComm::prepareForBeta()
 {
-    renderTypeBeta = NORMAL;
+    for (auto& [idx, type] : renderTypeBeta)
+        type = NORMAL;
 }
 
 ZENO_API void GlobalComm::clear_objects() {
@@ -1193,16 +1194,23 @@ ZENO_API GlobalComm::RenderType GlobalComm::getRenderType()
     return renderType;
 }
 
-ZENO_API void GlobalComm::setRenderTypeBeta(RenderType type)
+ZENO_API void GlobalComm::setRenderTypeBeta(int bateEnginIdx, RenderType type)
 {
     std::lock_guard lck(g_objsMutex);
-    renderTypeBeta = type;
+    renderTypeBeta[bateEnginIdx] = type;
 }
 
-ZENO_API GlobalComm::RenderType GlobalComm::getRenderTypeBeta()
+ZENO_API GlobalComm::RenderType GlobalComm::getRenderTypeBeta(int bateEnginIdx)
 {
     std::lock_guard lck(g_objsMutex);
-    return renderTypeBeta;
+    auto& it = renderTypeBeta.find(bateEnginIdx);
+    if (it == renderTypeBeta.end())
+    {
+        return UNDEFINED;
+    }
+    else {
+        return (*it).second;
+    }
 }
 
 ZENO_API MapObjects GlobalComm::getLightObjs()

--- a/zenovis/include/zenovis/bate/GraphicsManager.h
+++ b/zenovis/include/zenovis/bate/GraphicsManager.h
@@ -58,7 +58,7 @@ struct GraphicsManager {
         return ins.has_changed();
     }
 
-    void update_objs(std::map<std::string, std::shared_ptr<zeno::IObject>> objs, std::map<std::string, std::shared_ptr<zeno::IObject>> newobjs) {
+    void update_objs(std::map<std::string, std::shared_ptr<zeno::IObject>> objs, std::map<std::string, std::shared_ptr<zeno::IObject>> newobjs, int bateEnginIdx) {
         realtime_graphics.clear();
         std::map<std::string, std::unique_ptr<IGraphic>> tmp;
         for (auto const& [key, obj] : objs) {
@@ -68,7 +68,7 @@ struct GraphicsManager {
             };
             auto it = graphics.m_curr.m_curr.find(key);
             if (it != graphics.m_curr.m_curr.end()) {
-                if (newobjs.find(key) != newobjs.end() && zeno::getSession().globalComm->getRenderTypeBeta() != zeno::GlobalComm::UNDEFINED)
+                if (newobjs.find(key) != newobjs.end() && zeno::getSession().globalComm->getRenderTypeBeta(bateEnginIdx) != zeno::GlobalComm::UNDEFINED)
                 {
                     auto ig = makeGraphic(scene, obj.get());
                     zeno::log_debug("load_object: loaded graphics to {}", ig.get());
@@ -89,6 +89,7 @@ struct GraphicsManager {
             }
         }
         graphics.m_curr.m_curr.swap(tmp);
+        zeno::getSession().globalComm->setRenderTypeBeta(bateEnginIdx, zeno::GlobalComm::UNDEFINED);
     }
 
     void draw() {

--- a/zenovis/src/bate/RenderEngineBate.cpp
+++ b/zenovis/src/bate/RenderEngineBate.cpp
@@ -18,6 +18,12 @@ struct RenderEngineBate : RenderEngine {
     std::unique_ptr<IGraphicDraw> primHighlight;
     Scene *scene;
 
+    int bateEnginIdx = 0;
+    int getEnginIdx() {
+        static int bateEnginIdxCounter = 0;
+        return ++bateEnginIdxCounter;
+    }
+
     auto setupState() {
         return std::tuple{
             opengl::scopeGLEnable(GL_BLEND), opengl::scopeGLEnable(GL_DEPTH_TEST),
@@ -37,12 +43,13 @@ struct RenderEngineBate : RenderEngine {
         hudGraphics.push_back(makeGraphicSelectBox(scene));
 
         primHighlight = makePrimitiveHighlight(scene);
+
+        bateEnginIdx = getEnginIdx();
     }
 
     void update() override {
         std::lock_guard lck(zeno::g_objsMutex);
-        graphicsMan->update_objs(zeno::getSession().globalComm->getCurrentFrameObjs(), zeno::getSession().globalComm->getNeedUpdateToviewObjs());
-        zeno::getSession().globalComm->setRenderTypeBeta(zeno::GlobalComm::UNDEFINED);
+        graphicsMan->update_objs(zeno::getSession().globalComm->getCurrentFrameObjs(), zeno::getSession().globalComm->getNeedUpdateToviewObjs(), bateEnginIdx);
     }
 
     void draw() override {


### PR DESCRIPTION
1. 屏蔽非cache选项，必须使用cache
2. 多viewport窗口时的更新问题
3. zencache名称中可能出现中文的情况
4. 计算进程报错时，将节点标记回dirty状态