### PR TITLE
Isolate cache objs

### DIFF
--- a/ui/zenoedit/cache/zcachemgr.cpp
+++ b/ui/zenoedit/cache/zcachemgr.cpp
@@ -124,7 +124,8 @@ bool ZCacheMgr::hasCacheOnly(QDir dir, bool& empty)
             empty = false;
             size_t sLen = strlen(zeno::iotags::sZencache_lockfile_prefix);
             if (info.fileName().right(9) != ".zencache" &&
-                info.fileName().left(sLen) != zeno::iotags::sZencache_lockfile_prefix)    //not zencache file or cachelock file
+                info.fileName().right(4) != ".vdb" &&
+                info.fileName().left(sLen) != zeno::iotags::sZencache_lockfile_prefix)    //not zencache file or vdb file or cachelock file
             {
                 return false;
             }
@@ -171,16 +172,24 @@ bool ZCacheMgr::nextRunSkipCreateDir(LAUNCH_PARAM& param)
     return true;
 }
 
-bool ZCacheMgr::nodeCacheExist(QString& id)
+bool ZCacheMgr::nodeCacheExist(QString& id, bool isStatic)
 {
     ZenoMainWindow* mainWin = zenoApp->getMainWindow();
     ZASSERT_EXIT(mainWin, false);
     if (lastRunCachePath.path() != ".")
     {
         QDir framPath = lastRunCachePath;
-        if (framPath.cd(QString::number(1000000 + mainWin->timelineInfo().currFrame).right(6)))
-            if (QFile(framPath.path() + "/" + id + ".zencache").exists())
-                return true;
+        if (isStatic)
+        {
+            if (framPath.cd("_static"))
+                if (QFile(framPath.path() + "/" + id + ".zencache").exists())
+                    return true;
+        }
+        else {
+            if (framPath.cd(QString::number(1000000 + mainWin->timelineInfo().currFrame).right(6)))
+                if (QFile(framPath.path() + "/" + id + ".zencache").exists())
+                    return true;
+        }
     }
     return false;
 }

--- a/ui/zenoedit/cache/zcachemgr.h
+++ b/ui/zenoedit/cache/zcachemgr.h
@@ -20,7 +20,7 @@ public:
     void removeObjTmpCacheDir();
     bool nextRunSkipCreateDir(LAUNCH_PARAM& param);
 
-    bool nodeCacheExist(QString& id);
+    bool nodeCacheExist(QString& id, bool isStatic);
 
 private:
     void initToViewNodesId();

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -1956,9 +1956,12 @@ void ZenoNode::onOptionsBtnToggled(STATUS_BTN btn, bool toggled)
 
     std::shared_ptr<ZCacheMgr> mgr = zenoApp->cacheMgr();
     ZASSERT_EXIT(mgr);
-    bool toggleCachedNodeViewBtn = btn == STATUS_VIEW && mgr->nodeCacheExist(m_index.data(ROLE_OBJID).toString());  //toggle viewBtn and it has been cached
+    bool toggleCachedNodeViewBtn = btn == STATUS_VIEW && mgr->nodeCacheExist(m_index.data(ROLE_OBJID).toString(), options & OPT_ONCE);  //toggle viewBtn and it has been cached
     if (!toggleCachedNodeViewBtn && m_subGpIndex.data(ROLE_OBJNAME).toString() == "main") {
-        pGraphsModel->markNodeDataChanged(m_index);
+        if (btn == STATUS_CACHE)
+            pGraphsModel->markNodeDataChanged(m_index, false);
+        else
+            pGraphsModel->markNodeDataChanged(m_index);
         onMarkDataChanged(true);
     }
 

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -94,10 +94,20 @@ void DisplayWidget::cleanUpScene()
 {
     if (zeno::getSession().globalComm) {
         zeno::getSession().globalComm->clear_objects();
+
         if (m_glView)
-            m_glView->update();
-        else
-            m_optixView->update();
+        {
+            Zenovis* vis = getZenoVis();
+            ZASSERT_EXIT(vis);
+            auto scene = vis->getSession()->get_scene();
+            ZASSERT_EXIT(scene);
+            auto engin = scene->renderMan->getEngine();
+            ZASSERT_EXIT(engin);
+            engin->update();
+        }
+        else {
+            m_optixView->updateEngine();
+        }
     }
 }
 

--- a/ui/zenoedit/viewport/optixviewport.h
+++ b/ui/zenoedit/viewport/optixviewport.h
@@ -40,6 +40,7 @@ public slots:
     void onSetSlidFeq(int feq);
     void onModifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString nodename, UI_VECTYPE skipParam);
     void onUpdateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam = UI_VECTYPE());
+    void onUpdateEngine();
 
 private:
     Zenovis *m_zenoVis;
@@ -77,6 +78,7 @@ public:
     void killThread();
     void setSlidFeq(int feq);
     void modifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString name, UI_VECTYPE skipParam);
+    void updateEngine();
 
 signals:
     void cameraAboutToRefresh();
@@ -96,6 +98,7 @@ signals:
     void sigscreenshoot(QString, QString, int, int);
     void sig_modifyLightData(UI_VECTYPE pos, UI_VECTYPE scale, UI_VECTYPE rotate, UI_VECTYPE color, float intensity, QString name, UI_VECTYPE skipParam);
     void sig_updateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam = UI_VECTYPE());
+    void sig_updateEngine();
 
 public slots:
     void onFrameRunFinished(int frame);

--- a/zeno/src/core/INode.cpp
+++ b/zeno/src/core/INode.cpp
@@ -99,18 +99,8 @@ ZENO_API void zeno::INode::writeTmpCaches()
 {
     GlobalComm::ViewObjects objs;
     for (auto const& [name, value] : outputs) 
-    {
         if (dynamic_cast<IObject*>(value.get()))
-        {
-            auto methview = value->method_node("view");
-            if (!methview.empty()) {
-                log_warn("{} cache to disk failed", myname);
-                return;
-            }
             objs.try_emplace(name, std::move(value->clone()));
-        }
-
-    }
 
     bool bStatic = (Once & m_status);
     int frameid = bStatic ? -1 : zeno::getSession().globalState->frameid;

--- a/zeno/src/core/INode.cpp
+++ b/zeno/src/core/INode.cpp
@@ -125,19 +125,6 @@ ZENO_API void zeno::INode::writeTmpCaches()
 }
 
 ZENO_API void INode::preApply() {
-
-    if (m_status & NodeStatus::Mute)
-    {
-        //just pass input data to output.
-        for (auto const& [name, _] : this->inputs) {
-            if (name == "SRC") continue;//sk
-            set_output(name, get_input(name));
-        }
-        return;
-    }
-    if ((m_status & NodeStatus::Once) && m_bFinishOnce)
-        return;
-
     auto& dc = graph->getDirtyChecker();
     bool bTmpCache = (m_status & NodeStatus::Cached);
     if (!dc.amIDirty(myname) && bTmpCache)
@@ -176,7 +163,6 @@ ZENO_API void INode::preApply() {
         }
     }
     log_debug("==> leave {}", myname);
-    m_bFinishOnce = true;
 }
 
 ZENO_API bool INode::requireInput(std::string const &ds) {
@@ -200,7 +186,23 @@ ZENO_API void INode::doOnlyApply() {
 ZENO_API void INode::doApply() {
     //if (checkApplyCondition()) {
     log_trace("--> enter {}", myname);
+
+    if (m_status & NodeStatus::Mute)
+    {
+        //just pass input data to output.
+        for (auto const& [name, _] : this->inputs) {
+            if (name == "SRC") continue;//sk
+            set_output(name, get_input(name));
+        }
+        return;
+    }
+    if ((m_status & NodeStatus::Once) && m_bFinishOnce)
+        return;
+
     preApply();
+
+    m_bFinishOnce = true;
+
     log_trace("--> leave {}", myname);
     //}
 

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -13,6 +13,9 @@
 #include <zeno/types/PrimitiveObject.h>
 #include "zeno/core/Session.h"
 #include "zeno/utils/vec.h"
+#include <zeno/types/PrimitiveObject.h>
+#include <zeno/VDBGrid.h>
+#include <openvdb/tools/VolumeToMesh.h>
 #ifdef __linux__
     #include<unistd.h>
     #include <sys/statfs.h>
@@ -47,6 +50,91 @@ static void markListIndex(const std::string& root, std::shared_ptr<ListObject> l
     }
 }
 
+static std::shared_ptr<VDBGrid> readSDF(std::string filepath)
+{
+    using GridTypes = std::tuple
+        < openvdb::points::PointDataGrid
+        , openvdb::FloatGrid
+        , openvdb::Vec3fGrid
+        , openvdb::Int32Grid
+        , openvdb::Vec3IGrid
+        >;
+    openvdb::io::File file(filepath);
+    file.open();
+    openvdb::GridPtrVecPtr my_grids = file.getGrids();
+    file.close();
+    std::shared_ptr<zeno::VDBGrid> sdf;
+    for (openvdb::GridPtrVec::iterator iter = my_grids->begin(); iter != my_grids->end(); ++iter) {
+        openvdb::GridBase::Ptr it = *iter;
+        if (zeno::static_for<0, std::tuple_size_v<GridTypes>>([&](auto i) {
+            using GridT = std::tuple_element_t<i, GridTypes>;
+        if ((*iter)->isType<GridT>()) {
+
+            auto pGrid = std::make_shared<zeno::VDBGridWrapper<GridT>>();
+            pGrid->m_grid = openvdb::gridPtrCast<GridT>(*iter);
+            sdf = pGrid;
+            return true;
+        }
+        return false;
+            })) {
+            return sdf;
+        }
+        else {
+            zeno::log_info("failed to readGenericVDBGrid: {}", filepath);
+            return std::make_shared<zeno::VDBIntGrid>();
+        };
+    }
+}
+
+static std::shared_ptr<zeno::PrimitiveObject> convertSDFToPrim(std::shared_ptr<zeno::VDBGrid> vdb)
+{
+    auto sdf = vdb->as<VDBFloatGrid>();
+    auto mesh = IObject::make<PrimitiveObject>();
+    auto adaptivity = 0;
+    auto isoValue = 0;
+    auto allowQuads = false;
+    std::vector<openvdb::Vec3s> points(0);
+    std::vector<openvdb::Vec3I> tris(0);
+    std::vector<openvdb::Vec4I> quads(0);
+    openvdb::tools::volumeToMesh(*(sdf->m_grid), points, tris, quads, isoValue, adaptivity, true);
+    mesh->resize(points.size());
+    auto& meshpos = mesh->add_attr<zeno::vec3f>("pos");
+#pragma omp parallel for
+    for (int i = 0; i < points.size(); i++)
+    {
+        meshpos[i] = zeno::vec3f(points[i][0], points[i][1], points[i][2]);
+    }
+    if (allowQuads) {
+        mesh->tris.resize(tris.size());
+        mesh->quads.resize(quads.size());
+#pragma omp parallel for
+        for (int i = 0; i < tris.size(); i++)
+        {
+            mesh->tris[i] = zeno::vec3i(tris[i][0], tris[i][1], tris[i][2]);
+        }
+#pragma omp parallel for
+        for (int i = 0; i < quads.size(); i++)
+        {
+            mesh->quads[i] = zeno::vec4i(quads[i][0], quads[i][1], quads[i][2], quads[i][3]);
+        }
+    }
+    else {
+        mesh->tris.resize(tris.size() + 2 * quads.size());
+#pragma omp parallel for
+        for (int i = 0; i < tris.size(); i++)
+        {
+            mesh->tris[i] = zeno::vec3i(tris[i][0], tris[i][1], tris[i][2]);
+        }
+#pragma omp parallel for
+        for (int i = 0; i < quads.size(); i++)
+        {
+            mesh->tris[i * 2 + tris.size()] = zeno::vec3i(quads[i][0], quads[i][1], quads[i][2]);
+            mesh->tris[i * 2 + 1 + tris.size()] = zeno::vec3i(quads[i][2], quads[i][3], quads[i][0]);
+        }
+    }
+    return mesh;
+}
+
 void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjects &objs, std::string key, bool dumpCacheVersionInfo) {
     if (cachedir.empty()) return;
 
@@ -78,14 +166,29 @@ void GlobalComm::toDisk(std::string cachedir, int frameid, GlobalComm::ViewObjec
         std::vector<size_t> poses;
         std::string keys;
         for (auto const& [key, obj] : objs) {
-            size_t bufsize = bufCaches.size();
+            //fix:cache vdb data
+            auto methview = obj->method_node("view");
+            if (!methview.empty()) {
+                std::string vdbcachepath = cachepath.string();
+                vdbcachepath.erase(vdbcachepath.size() - 9);
+                vdbcachepath = vdbcachepath + "_" + std::filesystem::u8path(key).string() + ".vdb";
+                auto data = obj->as<VDBGrid>();
+                data->output(vdbcachepath);
 
-            std::back_insert_iterator<std::vector<char>> it(bufCaches);
-            if (encodeObject(obj.get(), bufCaches))
-            {
                 keys.push_back('\a');
-                keys.append(key);
-                poses.push_back(bufsize);
+                keys.append(key + ":isVDB");
+                poses.push_back(bufCaches.size());
+            }
+            else {
+                size_t bufsize = bufCaches.size();
+
+                std::back_insert_iterator<std::vector<char>> it(bufCaches);
+                if (encodeObject(obj.get(), bufCaches))
+                {
+                    keys.push_back('\a');
+                    keys.append(key);
+                    poses.push_back(bufsize);
+                }
             }
         }
         keys.push_back('\a');
@@ -285,13 +388,25 @@ bool GlobalComm::fromDiskByObjsManager(std::string cachedir, int frameid, Global
                 }
                 const char* p = dat.data() + pos + poses[lastObjIdx];
 
-                zeno::zany decodedObj = decodeObject(p, poses[lastObjIdx + 1] - poses[lastObjIdx]);
+                if (keys[lastObjIdx].find(":isVDB") != std::string::npos)
+                {
+                    //fix: readVDB and convert to prim
+                    std::string vdbcachepath = cachePath.string();
+                    vdbcachepath.erase(vdbcachepath.size() - 9);
+                    vdbcachepath = vdbcachepath + "_" + std::filesystem::u8path(keys[lastObjIdx].substr(0, keys[lastObjIdx].find_first_of(":"))).string() + ".vdb";
+                    std::shared_ptr<zeno::VDBGrid> sdf = readSDF(vdbcachepath);
+                    std::shared_ptr<zeno::PrimitiveObject> prim = convertSDFToPrim(sdf);
+                    convertToView(prim, nodeid, nodeid);
+                }
+                else {
+                    zeno::zany decodedObj = decodeObject(p, poses[lastObjIdx + 1] - poses[lastObjIdx]);
+                    convertToView(decodedObj, nodeid, nodeid);
+                }
                 //if (std::shared_ptr<ListObject> spListObj = std::dynamic_pointer_cast<ListObject>(decodedObj))
                 //{
                 //    markListIndex(nodeid, spListObj);
                 //}
 
-                convertToView(decodedObj, nodeid, nodeid);
             }
         }
     }
@@ -429,13 +544,24 @@ bool GlobalComm::fromDiskByObjsManagerStatic(std::string cachedir, GlobalComm::V
             }
             const char* p = dat.data() + pos + poses[lastObjIdx];
 
-            zeno::zany decodedObj = decodeObject(p, poses[lastObjIdx + 1] - poses[lastObjIdx]);
+            if (keys[lastObjIdx].find(":isVDB") != std::string::npos)
+            {
+                //fix: readVDB and convert to prim
+                std::string vdbcachepath = cachePath.string();
+                vdbcachepath.erase(vdbcachepath.size() - 9);
+                vdbcachepath = vdbcachepath + "_" + std::filesystem::u8path(keys[lastObjIdx].substr(0, keys[lastObjIdx].find_first_of(":"))).string() + ".vdb";
+                std::shared_ptr<zeno::VDBGrid> sdf = readSDF(vdbcachepath);
+                std::shared_ptr<zeno::PrimitiveObject> prim = convertSDFToPrim(sdf);
+                convertToView(prim, nodeid, nodeid);
+            }
+            else {
+                zeno::zany decodedObj = decodeObject(p, poses[lastObjIdx + 1] - poses[lastObjIdx]);
+                convertToView(decodedObj, nodeid, nodeid);
+            }
             //if (std::shared_ptr<ListObject> spListObj = std::dynamic_pointer_cast<ListObject>(decodedObj))
             //{
             //    markListIndex(nodeid, spListObj);
             //}
-
-            convertToView(decodedObj, nodeid, nodeid);
         }
     }
 
@@ -503,7 +629,20 @@ bool GlobalComm::fromDiskByRunner(std::string cachedir, int frameid, GlobalComm:
                 log_error("zeno cache file broken (4.{})", k);
             }
             const char* p = dat.data() + pos + poses[k];
-            objs.try_emplace(keys[k], decodeObject(p, poses[k + 1] - poses[k]));
+
+            if (keys[k].find(":isVDB") != std::string::npos)
+            {
+                //fix: readVDB and convert to prim
+                std::string& socketName = keys[k].substr(0, keys[k].find_first_of(":"));
+                std::string vdbcachepath = filePath.string();
+                vdbcachepath.erase(vdbcachepath.size() - 9);
+                vdbcachepath = vdbcachepath + "_" + std::filesystem::u8path(socketName).string() + ".vdb";
+                std::shared_ptr<zeno::VDBGrid> sdf = readSDF(vdbcachepath);
+                objs.try_emplace(socketName, sdf);
+            }
+            else {
+                objs.try_emplace(keys[k], decodeObject(p, poses[k + 1] - poses[k]));
+            }
         }
     }
     return true;

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -818,6 +818,14 @@ void GlobalComm::prepareForOptix(std::map<std::string, std::shared_ptr<zeno::IOb
     else
         renderType = NORMAL;
 
+    //fix: hdrsky obj need updateAll
+    for (auto& [key, obj] : m_newToviewObjs)
+        if (key.find("HDRSky") != std::string::npos)
+        {
+            renderType = NORMAL;
+            break;
+        }
+
     m_lightObjects.clear();
     for (auto const& [key, obj] : objs) {
         if (auto prim_in = dynamic_cast<zeno::PrimitiveObject*>(obj.get())) {


### PR DESCRIPTION
1. clean up scene和运行hdrsky时存在的问题
2. 处理once的逻辑移到INode::doAppy
3. 点击cache标签时仅markdirty自身节点
4. 存取sdf格式cache
