### PR TITLE
Isolate cache objs

### DIFF
--- a/ui/zenoedit/dock/docktabcontent.cpp
+++ b/ui/zenoedit/dock/docktabcontent.cpp
@@ -489,12 +489,6 @@ void DockContent_Editor::initConnections()
                 QMessageBox::warning(nullptr, tr("RunLightCamera"), tr("This function can only be used in cache mode."));
                 return;
             }
-            QVector<DisplayWidget*> views = pMainWin->viewports();
-            for (auto displayWid : views) {
-                if (!displayWid->isGLViewport()) {
-                    displayWid->setRenderSeparately(false, false);
-                }
-            }
             pMainWin->setAlways(true);
         }
         else {
@@ -529,15 +523,6 @@ void DockContent_Editor::initConnections()
         m_btnKill->setVisible(true);
         ZenoMainWindow *pMainWin = zenoApp->getMainWindow();
         ZASSERT_EXIT(pMainWin);
-        std::function<void(bool, bool)> setOptixUpdateSeparately = [=](bool updateLightCameraOnly, bool updateMatlOnly) {
-            QVector<DisplayWidget *> views = pMainWin->viewports();
-            for (auto displayWid : views) {
-                if (!displayWid->isGLViewport()) {
-                    displayWid->setRenderSeparately(updateLightCameraOnly, updateMatlOnly);
-                }
-            }
-        };
-        setOptixUpdateSeparately(false, false);
         pMainWin->onRunTriggered();
     });
 

--- a/ui/zenoedit/launch/viewdecode.cpp
+++ b/ui/zenoedit/launch/viewdecode.cpp
@@ -168,7 +168,9 @@ struct PacketProc {
             QString ident = QString::fromStdString(objKey);
             IGraphsModel* pModel = zenoApp->graphsManagment()->currentModel();
             QModelIndex& idx = pModel->nodeIndex(ident);
-            pModel->markNodeDataUnchanged(idx);
+            if (idx.isValid()) {
+                pModel->markNodeDataUnchanged(idx);
+            }
         } else {
             zeno::log_warn("unknown packet action type {}", action);
             return false;

--- a/ui/zenoedit/nodesys/zenonode.cpp
+++ b/ui/zenoedit/nodesys/zenonode.cpp
@@ -189,8 +189,10 @@ ZLayoutBackground* ZenoNode::initHeaderWidget(IGraphsModel* pGraphsModel)
     NODE_TYPE type = static_cast<NODE_TYPE>(m_index.data(ROLE_NODETYPE).toInt());
 
     QColor clrHeaderBg;
-    if (type == NO_VERSION_NODE || pGraphsModel->IsDeprecatedhNode(m_index))
+    if (type == NO_VERSION_NODE)
         clrHeaderBg = QColor(83, 83, 85);
+    else if (pGraphsModel->IsDeprecatedhNode(m_index))
+        clrHeaderBg = QColor("#FF8000");
     else if (pGraphsModel->IsSubGraphNode(m_index))
         clrHeaderBg = QColor("#1D5F51");
     else

--- a/ui/zenoedit/viewport/displaywidget.cpp
+++ b/ui/zenoedit/viewport/displaywidget.cpp
@@ -217,13 +217,6 @@ void DisplayWidget::setSimpleRenderOption()
         m_glView->setSimpleRenderOption();
 }
 
-void DisplayWidget::setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly) {
-    if (m_optixView)
-    {
-        m_optixView->setRenderSeparately(updateLightCameraOnly, updateMatlOnly);
-    }
-}
-
 bool DisplayWidget::isCameraMoving() const
 {
     if (m_glView)
@@ -548,9 +541,6 @@ void DisplayWidget::onSliderValueChanged(int frame)
     ZTimeline *timeline = mainWin->timeline();
     ZASSERT_EXIT(timeline);
 
-    for (auto displayWid : mainWin->viewports())
-        if (!displayWid->isGLViewport())
-            displayWid->setRenderSeparately(false, false);
     if (mainWin->isAlways())
     {
         auto pGraphsMgr = zenoApp->graphsManagment();

--- a/ui/zenoedit/viewport/displaywidget.h
+++ b/ui/zenoedit/viewport/displaywidget.h
@@ -42,7 +42,6 @@ public:
     void setSafeFrames(bool bLock, int nx, int ny);
     void setCameraRes(const QVector2D& res);
     void setSimpleRenderOption();
-    void setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly);
     bool isCameraMoving() const;
     bool isPlaying() const;
     bool isGLViewport() const;

--- a/ui/zenoedit/viewport/optixviewport.cpp
+++ b/ui/zenoedit/viewport/optixviewport.cpp
@@ -70,7 +70,6 @@ void OptixWorker::onPlayToggled(bool bToggled)
     else {
         m_pTimer->start(m_sampleFeq);
     }
-    setRenderSeparately(false, false);
 }
 
 void OptixWorker::onSetSlidFeq(int feq)
@@ -164,12 +163,6 @@ void OptixWorker::onFrameSwitched(int frame)
 void OptixWorker::cancelRecording()
 {
     m_bRecording = false;
-}
-
-void OptixWorker::setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly) {
-    auto scene = m_zenoVis->getSession()->get_scene();
-    scene->drawOptions->updateLightCameraOnly = updateLightCameraOnly;
-    scene->drawOptions->updateMatlOnly = updateMatlOnly;
 }
 
 void OptixWorker::onSetSafeFrames(bool bLock, int nx, int ny) {
@@ -398,7 +391,6 @@ ZOptixViewport::ZOptixViewport(QWidget* parent)
 
     connect(this, &ZOptixViewport::sig_switchTimeFrame, m_worker, &OptixWorker::onFrameSwitched);
     connect(this, &ZOptixViewport::sig_togglePlayButton, m_worker, &OptixWorker::onPlayToggled);
-    connect(this, &ZOptixViewport::sig_setRenderSeparately, m_worker, &OptixWorker::setRenderSeparately);
     connect(this, &ZOptixViewport::sig_setLoopPlaying, m_worker, &OptixWorker::onSetLoopPlaying);
     connect(this, &ZOptixViewport::sig_setSlidFeq, m_worker, &OptixWorker::onSetSlidFeq);
     connect(this, &ZOptixViewport::sig_modifyLightData, m_worker, &OptixWorker::onModifyLightData);
@@ -406,7 +398,6 @@ ZOptixViewport::ZOptixViewport(QWidget* parent)
     connect(this, &ZOptixViewport::sig_updateEngine, m_worker, &OptixWorker::onUpdateEngine);
 
     zeno::getSession().globalComm->setRenderType(zeno::GlobalComm::NORMAL);
-    setRenderSeparately(false, false);
     m_thdOptix.start();
 }
 
@@ -420,10 +411,6 @@ void ZOptixViewport::setSimpleRenderOption()
 {
     auto scene = m_zenovis->getSession()->get_scene();
     scene->drawOptions->simpleRender = true;
-}
-
-void ZOptixViewport::setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly) {
-    emit sig_setRenderSeparately(updateLightCameraOnly, updateMatlOnly);
 }
 
 void ZOptixViewport::cameraLookTo(int dir)

--- a/ui/zenoedit/viewport/optixviewport.cpp
+++ b/ui/zenoedit/viewport/optixviewport.cpp
@@ -360,7 +360,7 @@ ZOptixViewport::ZOptixViewport(QWidget* parent)
 
     //fake GL
     m_zenovis->initializeGL();
-    m_zenovis->setCurrentFrameId(0);    //correct frame automatically.
+    m_zenovis->setCurrentFrameId(zenoApp->getMainWindow()->timelineInfo().currFrame);    //correct frame automatically.
 
     m_camera = new CameraControl(m_zenovis, nullptr, nullptr, this);
     m_zenovis->m_camera_control = m_camera;

--- a/ui/zenoedit/viewport/optixviewport.h
+++ b/ui/zenoedit/viewport/optixviewport.h
@@ -33,7 +33,6 @@ public slots:
     void onPlayToggled(bool bToggled);
     void onFrameSwitched(int frame);
     void cancelRecording();
-    void setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly);
     void onSetSafeFrames(bool bLock, int nx, int ny);
     bool recordFrame_impl(VideoRecInfo recInfo, int frame);
     void onSetLoopPlaying(bool enbale);
@@ -60,7 +59,6 @@ public:
     ZOptixViewport(QWidget* parent = nullptr);
     ~ZOptixViewport();
     void setSimpleRenderOption();
-    void setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly);
     void cameraLookTo(int dir);
     void updateCameraProp(float aperture, float disPlane, UI_VECTYPE skipParam = UI_VECTYPE());
     void updatePerspective();
@@ -92,7 +90,6 @@ signals:
     void sig_switchTimeFrame(int frame);
     void sig_setSafeFrames(bool bLock, int nx, int ny);
     void sig_cancelRecording();
-    void sig_setRenderSeparately(bool updateLightCameraOnly, bool updateMatlOnly);
     void sig_setLoopPlaying(bool enable);
     void sig_setSlidFeq(int feq);
     void sigscreenshoot(QString, QString, int, int);

--- a/ui/zenoedit/zenomainwindow.cpp
+++ b/ui/zenoedit/zenomainwindow.cpp
@@ -918,12 +918,6 @@ void ZenoMainWindow::optixClientRun(int port, const char* cachedir, int cachenum
                     bool updateMatlOnly = renderObj["applyMaterialOnly"].GetInt();
                     ZenoMainWindow* pMainWin = zenoApp->getMainWindow();
                     ZASSERT_EXIT(pMainWin);
-                    QVector<DisplayWidget*> views = pMainWin->viewports();
-                    for (auto displayWid : views) {
-                        if (!displayWid->isGLViewport()) {
-                            displayWid->setRenderSeparately(updateLightCameraOnly, updateMatlOnly);
-                        }
-                    }
                     if (m_bOptixProcRecording)
                     {
                         DisplayWidget* displayWid = getOptixWidget();

--- a/ui/zenomodel/src/graphsmodel.cpp
+++ b/ui/zenomodel/src/graphsmodel.cpp
@@ -156,7 +156,7 @@ bool GraphsModel::newMaterialSubgraph(const QModelIndex & currentSubIdx, const Q
     //add material subgraph node
     const QString& subIdent = NodesMgr::createNewNode(this, currentSubIdx, graphName, pos);
     auto subgNodeIdx = nodeIndex(subIdent);
-    QVariant newValue = OPT_VIEW;
+    QVariant newValue = OPT_VIEW | OPT_CACHE;
     ModelSetData(subgNodeIdx, newValue, ROLE_OPTIONS);
    endTransaction();
    emit dataChanged(subgIdx, subgIdx);

--- a/zeno/src/extra/GlobalComm.cpp
+++ b/zeno/src/extra/GlobalComm.cpp
@@ -958,6 +958,14 @@ void GlobalComm::prepareForOptix(std::map<std::string, std::shared_ptr<zeno::IOb
     else
         renderType = NORMAL;
 
+    //fix: no new objs also need setCamera
+    if (renderType == UNDEFINED)
+        for (auto& [key, obj] : objs)
+            if (auto cam = std::dynamic_pointer_cast<zeno::CameraObject>(obj)) {
+                renderType = LIGHT_CAMERA;
+                break;
+            }
+
     //fix: hdrsky obj need updateAll
     for (auto& [key, obj] : m_newToviewObjs)
         if (key.find("HDRSky") != std::string::npos)

--- a/zenovis/include/zenovis/bate/GraphicsManager.h
+++ b/zenovis/include/zenovis/bate/GraphicsManager.h
@@ -79,6 +79,10 @@ struct GraphicsManager {
                 else {
                     tmp.insert(std::make_pair(key, std::move(it->second)));
                 }
+                //fix: no new objs also need setCamera
+                if (auto cam = std::dynamic_pointer_cast<zeno::CameraObject>(obj))
+                    if (newobjs.find(key) == newobjs.end() && zeno::getSession().globalComm->getRenderTypeBeta(bateEnginIdx) != zeno::GlobalComm::UNDEFINED)
+                        scene->camera->setCamera(cam->get());
             }
             else {
                 auto ig = makeGraphic(scene, obj.get());

--- a/zenovis/src/optx/RenderEngineOptx.cpp
+++ b/zenovis/src/optx/RenderEngineOptx.cpp
@@ -901,6 +901,7 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
         {
             auto renderType = objsMan->getRenderTypeByObjects(transObjs);
             meshNeedUpdate = matNeedUpdate = true;
+            scene->drawOptions->updateMatlOnly = scene->drawOptions->updateLightCameraOnly = false;
             if (renderType == zeno::GlobalComm::MATERIAL)
             {
                 scene->drawOptions->updateMatlOnly = true;
@@ -954,6 +955,7 @@ struct RenderEngineOptx : RenderEngine, zeno::disable_copy {
             }
             if (rendertype == zeno::GlobalComm::NORMAL)
             {
+                scene->drawOptions->updateMatlOnly = scene->drawOptions->updateLightCameraOnly = false;
                 matNeedUpdate = meshNeedUpdate = lightNeedUpdate = true;
             }
             objsMan->setRenderType(zeno::GlobalComm::UNDEFINED);


### PR DESCRIPTION
1. 没有节点被运行时依然更新相机
2. 创建材质子图开启cache_opt
3. deprecated节点黄色
4. 光追初始化时帧数和时间轴保持一致

