### PR TITLE
[BUG#2024] fixed crypto/Qt version issues for ubuntu 20.04 compile.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -46,7 +46,7 @@ If you use Linux the setup would be much easier, simply run these commands:
 
 ```bash
 sudo apt-get install -y git cmake make g++
-sudo apt-get install -y qt5-default libqt5svg5-dev
+sudo apt-get install -y qt5-default libqt5svg5-dev libcrypto++-dev
 ```
 
 > NOTE: We highly recommend to use **Ubuntu 20.04 (or above)** whenever possible.

--- a/ui/zenoedit/panel/zlogpanel.cpp
+++ b/ui/zenoedit/panel/zlogpanel.cpp
@@ -334,7 +334,7 @@ void ZPlainLogPanel::contextMenuEvent(QContextMenuEvent* event)
             QString cmd = text;
             cmd = cmd.replace(str, newStr);
             QProcess process;
-            auto cmdArgs = process.splitCommand(cmd);
+            auto cmdArgs = cmd.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
             process.setProgram(cmdArgs.takeFirst());
             QStringList args;
             for (int i = 0; i < cmdArgs.size(); i++)

--- a/ui/zenoedit/panel/zlogpanel.cpp
+++ b/ui/zenoedit/panel/zlogpanel.cpp
@@ -334,7 +334,7 @@ void ZPlainLogPanel::contextMenuEvent(QContextMenuEvent* event)
             QString cmd = text;
             cmd = cmd.replace(str, newStr);
             QProcess process;
-            auto cmdArgs = cmd.split(QRegularExpression("\\s+"), QString::SkipEmptyParts);
+            auto cmdArgs = process.splitCommand(cmd);
             process.setProgram(cmdArgs.takeFirst());
             QStringList args;
             for (int i = 0; i < cmdArgs.size(); i++)

--- a/zenovis/xinxinoptix/OptiXStuff.h
+++ b/zenovis/xinxinoptix/OptiXStuff.h
@@ -849,8 +849,8 @@ inline void calc_sky_cdf_map(cuTexture* tex, int nx, int ny, int nc, std::functi
 }
 
 static std::string calculateMD5(const std::vector<char>& input) {
-    CryptoPP::byte digest[CryptoPP::Weak::MD5::DIGESTSIZE];
-    CryptoPP::Weak::MD5().CalculateDigest(digest, (const CryptoPP::byte*)input.data(), input.size());
+    unsigned char digest[CryptoPP::Weak::MD5::DIGESTSIZE];
+    CryptoPP::Weak::MD5().CalculateDigest(digest, (const unsigned char*)input.data(), input.size());
     CryptoPP::HexEncoder encoder;
     std::string output;
     encoder.Attach(new CryptoPP::StringSink(output));


### PR DESCRIPTION
As #2024 , we fixd the BUG of compiling of ubuntu 20.04.
- add a crypto library insatll command for ubuntu 20.04.
- support ubuntu 20.04's default crypto version for compiling.
- fixed the problem which ubuntu 20.04's default Qt 5.12 version has no `splitCommand` function.

Related issue number (if any) = #2024 
